### PR TITLE
feat(attachment): add attachment serving API with markdown integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ GITHUB_REPO=your_blog_repo
 # Path to your markdown files within the repository
 # Default is 'posts' if not specified
 POSTS_PATH=posts
+
+# Attachment
+ATTACHMENT_PATH=attachment

--- a/src/app/api/attachment/[...path]/route.ts
+++ b/src/app/api/attachment/[...path]/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { path: string[] } }
+) {
+  try {
+    const { path } = params;
+
+    // Get environment variables
+    const githubToken = process.env.GITHUB_TOKEN;
+    const githubOwner = process.env.GITHUB_OWNER;
+    const githubRepo = process.env.GITHUB_REPO;
+    const attachmentPath = process.env.ATTACHMENT_PATH || "attachment";
+
+    // Validate required environment variables
+    if (!githubToken || !githubOwner || !githubRepo) {
+      return NextResponse.json(
+        { error: "Missing required GitHub configuration" },
+        { status: 500 }
+      );
+    }
+
+    // Construct the file path
+    const filePath = path.join("/");
+    const fullPath = `${attachmentPath}/${filePath}`;
+
+    // Fetch file from GitHub API
+    const githubUrl = `https://api.github.com/repos/${githubOwner}/${githubRepo}/contents/${fullPath}`;
+
+    const response = await fetch(githubUrl, {
+      headers: {
+        Authorization: `token ${githubToken}`,
+        Accept: "application/vnd.github.v3+json",
+        "User-Agent": "NextJS-Blog-App",
+      },
+      // Add cache control
+      next: { revalidate: 3600 }, // Cache for 1 hour
+    });
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        return NextResponse.json({ error: "File not found" }, { status: 404 });
+      }
+
+      return NextResponse.json(
+        { error: "Failed to fetch file from GitHub" },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+
+    // GitHub API returns base64 encoded content for files
+    if (data.type !== "file") {
+      return NextResponse.json(
+        { error: "Path does not point to a file" },
+        { status: 400 }
+      );
+    }
+
+    // Decode base64 content
+    const fileContent = Buffer.from(data.content, "base64");
+
+    // Determine content type based on file extension
+    const getContentType = (filename: string): string => {
+      const ext = filename.toLowerCase().split(".").pop();
+      const mimeTypes: { [key: string]: string } = {
+        jpg: "image/jpeg",
+        jpeg: "image/jpeg",
+        png: "image/png",
+        gif: "image/gif",
+        webp: "image/webp",
+        svg: "image/svg+xml",
+        pdf: "application/pdf",
+        txt: "text/plain",
+        md: "text/markdown",
+        json: "application/json",
+        css: "text/css",
+        js: "application/javascript",
+        html: "text/html",
+      };
+
+      return mimeTypes[ext || ""] || "application/octet-stream";
+    };
+
+    const contentType = getContentType(data.name);
+
+    // Return the file with appropriate headers
+    return new NextResponse(fileContent, {
+      status: 200,
+      headers: {
+        "Content-Type": contentType,
+        "Cache-Control": "public, max-age=3600, s-maxage=3600",
+        "Content-Disposition": `inline; filename="${data.name}"`,
+        "Content-Length": fileContent.length.toString(),
+      },
+    });
+  } catch (error) {
+    console.error("Error serving attachment:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,6 +17,15 @@
   .markdown-body {
     background-color: unset;
   }
+  @media (prefers-color-scheme: dark) {
+  }
+
+  .markdown-body {
+    img {
+      border-radius: 12px;
+      box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
+    }
+  }
 }
 
 :root {
@@ -65,40 +74,6 @@ body {
   to {
     opacity: 1;
     transform: translateY(0);
-  }
-}
-
-@keyframes shooting-star {
-  0% {
-    transform: translateX(-100px) translateY(-100px);
-    opacity: 0;
-  }
-  10% {
-    opacity: 1;
-  }
-  90% {
-    opacity: 1;
-  }
-  100% {
-    transform: translateX(300px) translateY(300px);
-    opacity: 0;
-  }
-}
-
-@keyframes shooting-star-delayed {
-  0% {
-    transform: translateX(-100px) translateY(-100px);
-    opacity: 0;
-  }
-  10% {
-    opacity: 1;
-  }
-  90% {
-    opacity: 1;
-  }
-  100% {
-    transform: translateX(200px) translateY(200px);
-    opacity: 0;
   }
 }
 

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -2,12 +2,16 @@ import { MarkdownAsync } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeStarryNight from "rehype-starry-night";
 import { all } from "@wooorm/starry-night";
+import { convertAttachmentUrls } from "@/lib/attachment";
 
 interface MarkdownRendererProps {
   content: string;
 }
 
 export default function MarkdownRenderer({ content }: MarkdownRendererProps) {
+  // Convert attachment URLs to API URLs
+  const processedContent = convertAttachmentUrls(content);
+
   return (
     <div className="markdown-body">
       <MarkdownAsync
@@ -16,7 +20,7 @@ export default function MarkdownRenderer({ content }: MarkdownRendererProps) {
           (options) => rehypeStarryNight({ ...options, grammars: all }),
         ]}
       >
-        {content}
+        {processedContent}
       </MarkdownAsync>
     </div>
   );

--- a/src/lib/attachment.ts
+++ b/src/lib/attachment.ts
@@ -1,0 +1,47 @@
+/**
+ * Utility functions for handling attachment URLs
+ */
+
+/**
+ * Generate a URL for an attachment file
+ * @param path - The path to the attachment file (e.g., "images/example.png")
+ * @returns The full URL to access the attachment via the API
+ */
+export function getAttachmentUrl(path: string): string {
+  // Remove leading slash if present
+  const cleanPath = path.startsWith("/") ? path.slice(1) : path;
+
+  // Return the API URL
+  return `/api/attachment/${cleanPath}`;
+}
+
+/**
+ * Check if a URL is an attachment URL
+ * @param url - The URL to check
+ * @returns True if the URL is an attachment URL
+ */
+export function isAttachmentUrl(url: string): boolean {
+  return url.includes("attachment/");
+}
+
+/**
+ * Convert attachment URLs in markdown content to API URLs
+ * @param content - The markdown content
+ * @returns The content with converted attachment URLs
+ */
+export function convertAttachmentUrls(content: string): string {
+  // Replace attachment URLs in markdown image syntax
+  // This regex matches any path that contains "attachment/" regardless of preceding directory levels
+  return content.replace(
+    /!\[([^\]]*)\]\(([^)]*attachment\/[^)]+)\)/g,
+    (match, alt, fullPath) => {
+      // Extract just the attachment part (attachment/xxx)
+      const attachmentMatch = fullPath.match(/attachment\/(.+)$/);
+      if (attachmentMatch) {
+        const attachmentPath = attachmentMatch[1];
+        return `![${alt}](${getAttachmentUrl(attachmentPath)})`;
+      }
+      return match; // Return original if no match found
+    }
+  );
+}


### PR DESCRIPTION
Add new API endpoint to serve attachment files from GitHub repository with proper content type detection and caching. Integrate attachment URL conversion in markdown renderer to automatically transform attachment paths to API URLs. Include styling improvements for markdown images with rounded corners and shadows.