### PR TITLE
Align story page colors with theme tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -94,14 +94,14 @@ body {
 }
 
 .story-page {
-  background: #f6f2e9;
+  background: var(--background);
   min-height: 100vh;
 }
 
 .story-shell {
-  background: #fcfaf4;
-  border: 1px solid #e6e1d6;
-  box-shadow: 0 10px 24px rgba(32, 24, 8, 0.08);
+  background: var(--background);
+  border: 1px solid var(--border-subtle);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
   padding: 20px;
 }
 
@@ -110,7 +110,7 @@ body {
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.28em;
-  color: #8b8170;
+  color: var(--text-muted);
 }
 
 .story-headline {
@@ -119,14 +119,14 @@ body {
   font-weight: 700;
   letter-spacing: 0.02em;
   line-height: 1.15;
-  color: #1b1b1b;
+  color: var(--foreground);
   margin: 0;
 }
 
 .story-rule {
   height: 1px;
   width: 100%;
-  background: #e1dbcf;
+  background: var(--border-subtle);
 }
 
 .story-body {
@@ -134,7 +134,7 @@ body {
   font-size: 1.06rem;
   line-height: 1.85;
   letter-spacing: 0.01em;
-  color: #1f1f1f;
+  color: var(--foreground);
   width: 100%;
   text-indent: 1.25em;
 }
@@ -148,107 +148,46 @@ body {
 .story-backlink {
   font-family: "Times New Roman", "Georgia", "Noto Serif", serif;
   font-size: 0.9rem;
-  color: #7a6e5a;
+  color: var(--accent-warm);
   text-decoration: underline;
   text-underline-offset: 4px;
 }
 
 .story-backlink:hover {
-  color: #4f4639;
+  color: color-mix(in srgb, var(--accent-warm) 82%, #000 18%);
 }
 
 .story-card {
-  background: #fffdf7;
-  border: 1px solid #e6e1d6;
+  background: var(--background);
+  border: 1px solid var(--border-subtle);
   font-family: "Times New Roman", "Georgia", "Noto Serif", serif;
 }
 
 .story-translation-word {
   padding: 0 0.15rem;
   margin: 0 0.05rem;
-  border-bottom: 1px dashed #b9ae9a;
-  color: #5a4e3e;
+  border-bottom: 1px dashed var(--border-subtle);
+  color: var(--text-muted);
 }
 
 .story-word {
   text-decoration: underline;
   text-decoration-thickness: 2px;
   text-underline-offset: 4px;
-  color: #7a6e5a;
+  color: var(--text-muted);
   transition: color 0.2s ease;
 }
 
 .story-word:hover {
-  color: #5b5142;
+  color: var(--foreground);
 }
 
 .story-word--focus {
-  color: #c2410c;
+  color: var(--accent-warm);
 }
 
 .story-word--focus:hover {
-  color: #9a3412;
-}
-
-@media (prefers-color-scheme: dark) {
-  .story-page {
-    background: #15130f;
-  }
-
-  .story-shell {
-    background: #15130f;
-    border: none;
-  }
-
-  .story-kicker {
-    color: #b1a793;
-  }
-
-  .story-headline {
-    color: #f0ede6;
-  }
-
-  .story-rule {
-    background: #3a3122;
-  }
-
-  .story-body {
-    color: #e8e4dc;
-  }
-
-  .story-backlink {
-    color: #c5bba6;
-  }
-
-  .story-backlink:hover {
-    color: #f0e9dd;
-  }
-
-  .story-card {
-    background: #221e17;
-    border-color: #3a3122;
-  }
-
-  .story-translation-word {
-    border-bottom-color: #7a6e5a;
-    color: #d2c9b8;
-  }
-
-  .story-word {
-    color: #c9bda8;
-  }
-
-  .story-word:hover {
-    color: #f0e9dd;
-  }
-
-  .story-word--focus {
-    color: #f1a95a;
-  }
-
-  .story-word--focus:hover {
-    color: #e38b3d;
-  }
+  color: color-mix(in srgb, var(--accent-warm) 72%, #000 28%);
 }
 
 /* Custom animations for homepage */

--- a/src/app/words/[slug]/components/daily-story.tsx
+++ b/src/app/words/[slug]/components/daily-story.tsx
@@ -223,7 +223,7 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
 
   return (
     <div className="space-y-6">
-      <div className="story-body text-lg text-gray-800 dark:text-gray-200 whitespace-pre-wrap">
+      <div className="story-body text-lg whitespace-pre-wrap">
         {parts.map((part, index) => {
           if (typeof part === "string") {
             const innerParts = splitEnglishWords(part);
@@ -247,7 +247,7 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
                       key={`word-inline-${index}-${innerIndex}-${inner.word}`}
                       type="button"
                       onClick={(event) => handleSelect(inner.word, event)}
-                      className="underline decoration-dashed decoration-1 underline-offset-4 text-current decoration-gray-300"
+                      className="underline decoration-dashed decoration-1 underline-offset-4 text-current decoration-[color:var(--border-subtle)]"
                     >
                       {inner.word}
                     </button>
@@ -262,7 +262,7 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
               key={`word-${index}-${word}`}
               type="button"
               onClick={(event) => handleSelect(word, event)}
-              className="story-word story-word--focus underline decoration-2 underline-offset-4 text-orange-600 hover:text-orange-700"
+              className="story-word story-word--focus"
             >
               {word}
             </button>
@@ -275,7 +275,7 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
           type="button"
           onClick={handleTranslate}
           disabled={isTranslating}
-          className="text-xs uppercase tracking-[0.18em] text-gray-500 hover:text-gray-800 disabled:opacity-50"
+          className="text-xs uppercase tracking-[0.18em] text-[color:var(--text-muted)] hover:text-foreground disabled:opacity-50"
         >
           {isTranslating
             ? "TRANSLATING..."
@@ -285,7 +285,7 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
         </button>
 
         {showTranslation && (
-          <div className="border-t border-dashed border-gray-300 pt-4 text-gray-700 whitespace-pre-wrap">
+          <div className="border-t border-dashed border-[color:var(--border-subtle)] pt-4 text-[color:var(--foreground)] whitespace-pre-wrap">
             {translationParts.map((part, index) => {
               if (typeof part === "string") {
                 return <span key={`t-text-${index}`}>{part}</span>;
@@ -328,12 +328,12 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
             <div className="story-card rounded-2xl p-5 shadow-lg">
               <div className="flex items-start justify-between gap-4 items-center">
                 <div>
-                  <h3 className="text-xl font-semibold text-gray-900">
+                  <h3 className="text-xl font-semibold text-foreground">
                     {popover.wordText}
                   </h3>
                   {popover.word?.phon && (
                     <div
-                      className="mt-2 text-sm text-gray-700"
+                      className="mt-2 text-sm text-[color:var(--text-muted)]"
                       dangerouslySetInnerHTML={{ __html: popover.word.phon }}
                     />
                   )}
@@ -342,15 +342,17 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
                   type="button"
                   onClick={handlePlay}
                   disabled={popover.audioLoading || !popover.audioSrc}
-                  className="text-sm font-medium text-orange-600 hover:text-orange-700 disabled:opacity-50"
+                  className="text-sm font-medium text-[color:var(--accent-warm)] hover:opacity-80 disabled:opacity-50"
                 >
                   {popover.audioLoading ? "生成中…" : "播放发音"}
                 </button>
               </div>
 
-              <div className="mt-4 text-gray-800">
+              <div className="mt-4 text-[color:var(--foreground)]">
                 {popover.loading ? (
-                  <span className="text-sm text-gray-500">生成中…</span>
+                  <span className="text-sm text-[color:var(--text-muted)]">
+                    生成中…
+                  </span>
                 ) : (
                   <Markdown>{popover.content || ""}</Markdown>
                 )}


### PR DESCRIPTION
### Motivation
- Unify the color system so the `story` page matches the `words` page palette in both light and dark modes. 
- Fix inconsistent word-card and inline word colors in dark mode so interactive elements use the same theme tokens.

### Description
- Replaced hard-coded story colors with theme CSS variables in `src/app/globals.css` for backgrounds, borders, foreground, muted text, and accent. 
- Updated rules for `.story-page`, `.story-shell`, `.story-card`, `.story-word`, `.story-translation-word`, `.story-backlink`, and related elements to use `var(--background)`, `var(--foreground)`, `var(--text-muted)`, `var(--border-subtle)`, and `var(--accent-warm)`. 
- Simplified and removed the duplicated dark-mode overrides and adjusted hover mixes to use `color-mix` so the same tokens drive both light and dark themes. 
- Adjusted `src/app/words/[slug]/components/daily-story.tsx` to remove hard-coded Tailwind color classes and instead reference theme variables for inline decorations, translation block, popover text, and audio button styling.

### Testing
- Started the development server and the app compiled the ` /words/[slug]/story` route (Next.js dev server started and pages compiled). 
- Captured a dark-mode screenshot using Playwright which produced an artifact (`story-dark.png`) for a visual check. 
- Observed a runtime 500 for `GET /words/test/story` due to missing Upstash Redis env vars during the run, so the visual check should be validated once Redis env is provided.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972e71f104c83339eddce87232aff04)