### PR TITLE
Remove story card border, enlarge story text, and require simpler vocabulary in AI prompt

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -100,8 +100,6 @@ body {
 
 .story-shell {
   background: var(--background);
-  border: 1px solid var(--border-subtle);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
   padding: 20px;
 }
 
@@ -131,7 +129,7 @@ body {
 
 .story-body {
   font-family: "Times New Roman", "Georgia", "Noto Serif", serif;
-  font-size: 1.06rem;
+  font-size: 1.2rem;
   line-height: 1.85;
   letter-spacing: 0.01em;
   color: var(--foreground);

--- a/src/lib/words/story.ts
+++ b/src/lib/words/story.ts
@@ -11,7 +11,8 @@ Requirements:
 2) Must include every given word exactly as provided (no case changes, no inflections).
 3) Wrap each word with [[word]].
 4) The meaning of each word in the story must match the sense in its example sentence.
-5) Output only the paragraph body—no title, list, explanation, or extra text.
+5) Use simple, common vocabulary (around CET-4 / CEFR B1 level), with short, clear sentences.
+6) Output only the paragraph body—no title, list, explanation, or extra text.
 `;
 
 const ensureStoryContainsAllWords = (story: string, words: string[]) => {


### PR DESCRIPTION
### Motivation
- Remove the card-like bordered styling from the story container so the story displays without a visible border and card effect. 
- Improve readability by increasing the story body font size. 
- Make generated stories easier to read by instructing the AI to use simple, common vocabulary (CET-4 / CEFR B1 level).

### Description
- Removed `border` and `box-shadow` from the story container in `src/app/globals.css` to eliminate the card/bordered effect and keep the shell background consistent with the page. 
- Increased the story text size by changing `.story-body` `font-size` from `1.06rem` to `1.2rem` in `src/app/globals.css`. 
- Updated the system prompt in `src/lib/words/story.ts` to add a requirement: `Use simple, common vocabulary (around CET-4 / CEFR B1 level), with short, clear sentences.` and adjusted numbering of the subsequent requirement.

### Testing
- Ran the development server with `pnpm dev`, which started and compiled the `/words/[slug]/story` route but the page returned `500` due to missing Upstash Redis config, so the route did not fully render. 
- Executed a Playwright script that visited `/words/demo/story` and produced a screenshot artifact successfully (artifact: `artifacts/story-page.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972ec6528cc8333933415133db84056)