### PR TITLE
refactor(ui): make markdown renderer async

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -57,55 +57,56 @@ function processChildren(children: ReactNode): ReactNode {
     : processHashtagsInText(children);
 }
 
-export default function MarkdownRenderer({
+export default async function MarkdownRenderer({
   content,
   date,
 }: MarkdownRendererProps) {
   // Convert attachment URLs to API URLs
   const processedContent = convertAttachmentUrls(content);
 
+  const rendered = await MarkdownAsync({
+    remarkPlugins: [remarkGfm],
+    rehypePlugins: [
+      (options) => rehypeStarryNight({ ...options, grammars: all }),
+    ],
+    components: {
+      header: ({ children }) => (
+        <div>
+          <h1 className="text-3xl font-medium font-display text-foreground mb-4 leading-tight tracking-tight mt-0">
+            {processChildren(children)}
+          </h1>
+          {date && (
+            <div className="flex flex-row items-center gap-2 text-gray-500 dark:text-gray-400">
+              <time>{format(new Date(date), "d MMM, yyyy")}</time>
+            </div>
+          )}
+        </div>
+      ),
+      p: ({ children }) => <p>{processChildren(children)}</p>,
+      li: ({ children }) => <li>{processChildren(children)}</li>,
+      img: ({ src, alt }) => {
+        return (
+          <div className="flex flex-col items-center my-4">
+            <Image
+              className="rounded-xl"
+              loading="lazy"
+              src={src as string}
+              alt={alt || "blog's image"}
+              width={650}
+              height={350}
+              quality={80}
+            />
+            <div className="italic text-sm mt-2 font-serif">{alt}</div>
+          </div>
+        );
+      },
+    },
+    children: processedContent,
+  });
+
   return (
     <div className="markdown-body">
-      <MarkdownAsync
-        remarkPlugins={[remarkGfm]}
-        rehypePlugins={[
-          (options) => rehypeStarryNight({ ...options, grammars: all }),
-        ]}
-        components={{
-          header: ({ children }) => (
-            <div>
-              <h1 className="text-3xl font-medium font-display text-foreground mb-4 leading-tight tracking-tight mt-0">
-                {processChildren(children)}
-              </h1>
-              {date && (
-                <div className="flex flex-row items-center gap-2 text-gray-500 dark:text-gray-400">
-                  <time>{format(new Date(date), "d MMM, yyyy")}</time>
-                </div>
-              )}
-            </div>
-          ),
-          p: ({ children }) => <p>{processChildren(children)}</p>,
-          li: ({ children }) => <li>{processChildren(children)}</li>,
-          img: ({ src, alt }) => {
-            return (
-              <div className="flex flex-col items-center my-4">
-                <Image
-                  className="rounded-xl"
-                  loading="lazy"
-                  src={src as string}
-                  alt={alt || "blog's image"}
-                  width={650}
-                  height={350}
-                  quality={80}
-                />
-                <div className="italic text-sm mt-2 font-serif">{alt}</div>
-              </div>
-            );
-          },
-        }}
-      >
-        {processedContent}
-      </MarkdownAsync>
+      {rendered}
     </div>
   );
 }


### PR DESCRIPTION
Make MarkdownRenderer an async component and await MarkdownAsync rendering. The markdown is now pre-rendered into a `rendered` variable using the same remark/rehype plugins and custom components, then returned inside the markdown container. This enables use of async plugins (e.g. rehypeStarryNight) and ensures attachment URLs are converted before rendering.