### PR TITLE
Lock document scroll while MobileSheet is open

### DIFF
--- a/src/components/MobileSheet.tsx
+++ b/src/components/MobileSheet.tsx
@@ -45,6 +45,19 @@ export const MobileSheet = ({
     return undefined;
   }, [open, mounted]);
 
+  useEffect(() => {
+    if (!open) return undefined;
+    const { body, documentElement } = document;
+    const previousBodyOverflow = body.style.overflow;
+    const previousHtmlOverflow = documentElement.style.overflow;
+    body.style.overflow = "hidden";
+    documentElement.style.overflow = "hidden";
+    return () => {
+      body.style.overflow = previousBodyOverflow;
+      documentElement.style.overflow = previousHtmlOverflow;
+    };
+  }, [open]);
+
   if (!mounted) return null;
 
   return (


### PR DESCRIPTION
### Motivation
- The mobile half-screen sheet allowed background scrolling when opened because the page `body`/`html` overflow was not locked, causing scroll bleed behind the sheet.

### Description
- Add a `useEffect` in `src/components/MobileSheet.tsx` that, while `open` is true, saves and sets `document.body.style.overflow` and `document.documentElement.style.overflow` to `"hidden"` and restores the previous values on cleanup so only the sheet (which uses `overflow-y-auto`) can scroll.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975baa558b083338535b375320abba7)