### PR TITLE
Highlight context sentence on word cards

### DIFF
--- a/src/app/words/[slug]/components/context-line.tsx
+++ b/src/app/words/[slug]/components/context-line.tsx
@@ -7,7 +7,15 @@ import { getExplanationAction } from "@/app/words/[slug]/actions";
 import Markdown from "react-markdown";
 import { MobileSheet } from "@/components/MobileSheet";
 
-export const ContextLine: React.FC<{ word: ILuluWord }> = ({ word }) => {
+type ContextLineProps = {
+  word: ILuluWord;
+  lineClassName?: string;
+};
+
+export const ContextLine: React.FC<ContextLineProps> = ({
+  word,
+  lineClassName,
+}) => {
   const [loading, setLoading] = useState<boolean>(false);
   const [exp, setExp] = useState<string>("");
   const [expand, setExpand] = useState<boolean>(false);
@@ -50,11 +58,8 @@ export const ContextLine: React.FC<{ word: ILuluWord }> = ({ word }) => {
 
   return (
     <>
-      <div onClick={handleGetExplanation}>
-        <div
-          className="inline-block"
-          dangerouslySetInnerHTML={{ __html: word.context.line }}
-        />
+      <div onClick={handleGetExplanation} className={lineClassName}>
+        <div dangerouslySetInnerHTML={{ __html: word.context.line }} />
       </div>
       {loading && (
         <Loader className="animate-spin mt-2 text-blue-500" size={16}></Loader>

--- a/src/app/words/[slug]/components/word/index.tsx
+++ b/src/app/words/[slug]/components/word/index.tsx
@@ -14,10 +14,14 @@ export const Index: React.FC<{ text: string; phon: string }> = ({
   };
 
   return (
-    <div className="mb-4">
-      <h3 className="mb-2" onClick={handlePlay}>
+    <div className="space-y-1">
+      <button
+        type="button"
+        className="text-base font-semibold text-foreground"
+        onClick={handlePlay}
+      >
         <span>{text}</span>
-      </h3>
+      </button>
       <div
         className={`flex gap-2 text-sm ${styles.phon}`}
         dangerouslySetInnerHTML={{ __html: phon }}

--- a/src/app/words/[slug]/page.tsx
+++ b/src/app/words/[slug]/page.tsx
@@ -36,9 +36,15 @@ export default async function DailyWordsPage({
         </div>
         <div className="markdown-body">
           {dailyWords.map((word) => (
-            <div key={word.uuid}>
+            <div
+              key={word.uuid}
+              className="mb-6 rounded-lg border border-black/5 bg-white/60 p-4 shadow-sm dark:border-white/10 dark:bg-white/5"
+            >
+              <ContextLine
+                word={word}
+                lineClassName="mb-4 cursor-pointer rounded-md border-l-4 border-orange-400/70 bg-orange-50/70 px-4 py-2 text-sm italic text-foreground/80 dark:bg-orange-950/40"
+              />
               <Index text={word.uuid} phon={word.phon} />
-              <ContextLine word={word} />
             </div>
           ))}
         </div>


### PR DESCRIPTION
### Motivation
- The word card should show the original sentence (context) prominently at the top in a quote/italic style instead of using the `word` itself as a title. 
- The word label should be de-emphasized and the pronunciation kept visible below. 
- Make the sentence styling configurable so the same component can be reused in different layouts.

### Description
- Updated `ContextLine` to accept a `lineClassName` prop and apply it to the clickable sentence container (`ContextLine` now uses `className={lineClassName}`).
- Reordered card layout on the words page so the context sentence appears above the word label and wrapped each word entry in a subtle rounded card with border and background (`src/app/words/[slug]/page.tsx`).
- Replaced the large `h3` title for the word with a smaller accessible `button` element and reduced visual weight while preserving the pronunciation and audio playback (`src/app/words/[slug]/components/word/index.tsx`).
- Passed a quote-like, italicized Tailwind class string from the page into `ContextLine` to achieve the desired visual (quote/italic) effect.

### Testing
- Started the dev server with `pnpm dev` and compiled the `/words/[slug]` route successfully.  
- Loaded `GET /words/2024-01-01` which returned `200` and captured a full-page screenshot via a Playwright script, producing an artifact for visual verification.  
- Observed Google Fonts download warnings during local run but the app fell back to system fonts and the page still rendered as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975c1ee5230833384eb2464bf8a8fe2)