### PR TITLE
Restore daily words layout and adjust mobile word sheet (move sentence to top quote)

### DIFF
--- a/src/app/words/[slug]/components/context-line.tsx
+++ b/src/app/words/[slug]/components/context-line.tsx
@@ -7,15 +7,7 @@ import { getExplanationAction } from "@/app/words/[slug]/actions";
 import Markdown from "react-markdown";
 import { MobileSheet } from "@/components/MobileSheet";
 
-type ContextLineProps = {
-  word: ILuluWord;
-  lineClassName?: string;
-};
-
-export const ContextLine: React.FC<ContextLineProps> = ({
-  word,
-  lineClassName,
-}) => {
+export const ContextLine: React.FC<{ word: ILuluWord }> = ({ word }) => {
   const [loading, setLoading] = useState<boolean>(false);
   const [exp, setExp] = useState<string>("");
   const [expand, setExpand] = useState<boolean>(false);
@@ -58,8 +50,11 @@ export const ContextLine: React.FC<ContextLineProps> = ({
 
   return (
     <>
-      <div onClick={handleGetExplanation} className={lineClassName}>
-        <div dangerouslySetInnerHTML={{ __html: word.context.line }} />
+      <div onClick={handleGetExplanation}>
+        <div
+          className="inline-block"
+          dangerouslySetInnerHTML={{ __html: word.context.line }}
+        />
       </div>
       {loading && (
         <Loader className="animate-spin mt-2 text-blue-500" size={16}></Loader>

--- a/src/app/words/[slug]/components/daily-story.tsx
+++ b/src/app/words/[slug]/components/daily-story.tsx
@@ -72,6 +72,9 @@ const splitEnglishWords = (text: string) => {
   return parts;
 };
 
+const stripHtml = (text: string) =>
+  text.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
+
 const STOP_WORDS = new Set([
   "a",
   "an",
@@ -418,30 +421,7 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
               onClose={closePopover}
               ariaLabel="Close word card"
               panelClassName="story-card"
-              bodyClassName="px-5 py-4 text-[color:var(--foreground)] scrollbar-hide"
-              header={
-                <div className="flex justify-between gap-4 items-center">
-                  <div>
-                    <h3 className="text-xl font-semibold text-foreground">
-                      {popover.wordText}
-                    </h3>
-                    {popover.word?.phon && (
-                      <div
-                        className="mt-2 text-sm text-[color:var(--text-muted)]"
-                        dangerouslySetInnerHTML={{ __html: popover.word.phon }}
-                      />
-                    )}
-                  </div>
-                  <button
-                    type="button"
-                    onClick={handlePlay}
-                    disabled={popover.audioLoading || !popover.audioSrc}
-                    className="text-sm font-medium text-[color:var(--accent-warm)] hover:opacity-80 disabled:opacity-50"
-                  >
-                    {popover.audioLoading ? "生成中…" : "播放发音"}
-                  </button>
-                </div>
-              }
+              bodyClassName="px-5 py-4 space-y-4 text-[color:var(--foreground)] scrollbar-hide"
               footer={
                 <button
                   type="button"
@@ -453,6 +433,27 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
                 </button>
               }
             >
+              {popover.word?.context.line && (
+                <div className="border-b border-dashed border-[color:var(--border-subtle)] pb-3 text-sm text-[color:var(--text-muted)]">
+                  <Markdown>{`> ${stripHtml(popover.word.context.line)}`}</Markdown>
+                </div>
+              )}
+              <div className="flex items-center justify-between gap-3">
+                {popover.word?.phon && (
+                  <div
+                    className="text-sm text-[color:var(--text-muted)]"
+                    dangerouslySetInnerHTML={{ __html: popover.word.phon }}
+                  />
+                )}
+                <button
+                  type="button"
+                  onClick={handlePlay}
+                  disabled={popover.audioLoading || !popover.audioSrc}
+                  className="text-sm font-medium text-[color:var(--accent-warm)] hover:opacity-80 disabled:opacity-50"
+                >
+                  {popover.audioLoading ? "生成中…" : "播放发音"}
+                </button>
+              </div>
               {popover.loading ? (
                 <span className="text-sm text-[color:var(--text-muted)]">
                   生成中…

--- a/src/app/words/[slug]/components/word/index.tsx
+++ b/src/app/words/[slug]/components/word/index.tsx
@@ -14,14 +14,10 @@ export const Index: React.FC<{ text: string; phon: string }> = ({
   };
 
   return (
-    <div className="space-y-1">
-      <button
-        type="button"
-        className="text-base font-semibold text-foreground"
-        onClick={handlePlay}
-      >
+    <div className="mb-4">
+      <h3 className="mb-2" onClick={handlePlay}>
         <span>{text}</span>
-      </button>
+      </h3>
       <div
         className={`flex gap-2 text-sm ${styles.phon}`}
         dangerouslySetInnerHTML={{ __html: phon }}

--- a/src/app/words/[slug]/page.tsx
+++ b/src/app/words/[slug]/page.tsx
@@ -36,15 +36,9 @@ export default async function DailyWordsPage({
         </div>
         <div className="markdown-body">
           {dailyWords.map((word) => (
-            <div
-              key={word.uuid}
-              className="mb-6 rounded-lg border border-black/5 bg-white/60 p-4 shadow-sm dark:border-white/10 dark:bg-white/5"
-            >
-              <ContextLine
-                word={word}
-                lineClassName="mb-4 cursor-pointer rounded-md border-l-4 border-orange-400/70 bg-orange-50/70 px-4 py-2 text-sm italic text-foreground/80 dark:bg-orange-950/40"
-              />
+            <div key={word.uuid}>
               <Index text={word.uuid} phon={word.phon} />
+              <ContextLine word={word} />
             </div>
           ))}
         </div>


### PR DESCRIPTION
### Motivation
- The previous change accidentally altered the word list layout instead of only updating the half-screen (mobile) sheet presentation, so the page structure needs to be restored and the mobile sheet behavior corrected.
- The mobile sheet should not show a redundant title area and should present the original sentence at the top as a markdown quote for context.

### Description
- Restored the daily words list layout so each list item shows the word header (`Index`) followed by the context line (`ContextLine`) as before by updating `src/app/words/[slug]/page.tsx` and `src/app/words/[slug]/components/word/index.tsx`.
- Simplified `ContextLine` props and markup by removing the extra wrapper class prop and returning to the inline display, in `src/app/words/[slug]/components/context-line.tsx`.
- Updated the mobile `MobileSheet` usage for word cards in `src/app/words/[slug]/components/daily-story.tsx` to remove the sheet header, display the original sentence as a markdown quote at the top, and move pronunciation/ playback controls into the sheet body.
- Added a small `stripHtml` helper to remove HTML tags when placing the original sentence into a markdown quote, and kept the existing desktop popover behavior unchanged.

### Testing
- Started the dev server with `pnpm dev --hostname 0.0.0.0 --port 3000` and the app served successfully (Next dev start succeeded). 
- The story route compiled (`/words/[slug]/story` compiled) and loaded in the running dev server without runtime errors.
- Ran a Playwright script to open the mobile story page and click a word to exercise the mobile sheet; the script captured a screenshot artifact successfully.
- Observed non-blocking warnings about Google Fonts failing to download in this environment (fallback fonts used); no functional failures were encountered.
- No unit test suite was run as part of these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975c7329b84833382a0136af989fef6)