### PR TITLE
Unify word card half-sheet: add shared WordCardPanel and WordCardSheet

### DIFF
--- a/src/app/words/[slug]/components/context-line.tsx
+++ b/src/app/words/[slug]/components/context-line.tsx
@@ -1,50 +1,102 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { ILuluWord } from "@/lib/words/types";
-import { Loader, X } from "lucide-react";
-import { getExplanationAction } from "@/app/words/[slug]/actions";
-import Markdown from "react-markdown";
-import { MobileSheet } from "@/components/MobileSheet";
+import { Loader } from "lucide-react";
+import {
+  getExplanationAction,
+  getWordCardAction,
+} from "@/app/words/[slug]/actions";
+import {
+  WordCardPanel,
+  type WordCardMode,
+} from "@/app/words/[slug]/components/word-card-panel";
+import { WordCardSheet } from "@/app/words/[slug]/components/word-card-sheet";
+
+const stripHtml = (text: string) =>
+  text.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
 
 export const ContextLine: React.FC<{ word: ILuluWord }> = ({ word }) => {
   const [loading, setLoading] = useState<boolean>(false);
-  const [exp, setExp] = useState<string>("");
+  const [brief, setBrief] = useState<string>("");
+  const [detail, setDetail] = useState<string>("");
   const [expand, setExpand] = useState<boolean>(false);
   const [regenerating, setRegenerating] = useState<boolean>(false);
+  const [activeMode, setActiveMode] = useState<WordCardMode>("detail");
+  const [briefLoading, setBriefLoading] = useState(false);
+  const [detailLoading, setDetailLoading] = useState(false);
 
   const handleClose = () => {
     setExpand(false);
   };
 
+  const requestDetail = useCallback(
+    async (options?: { force?: boolean }) => {
+      setDetailLoading(true);
+      try {
+        const text = await getExplanationAction(word, options);
+        setDetail(text);
+        setExpand(true);
+      } catch {
+        setDetail("请求失败");
+      } finally {
+        setDetailLoading(false);
+      }
+    },
+    [word],
+  );
+
+  const requestBrief = useCallback(
+    async (options?: { force?: boolean }) => {
+      setBriefLoading(true);
+      try {
+        const storyContext = stripHtml(word.context.line) || word.word;
+        const text = await getWordCardAction(word, storyContext, options);
+        setBrief(text);
+        setExpand(true);
+      } catch {
+        setBrief("请求失败");
+      } finally {
+        setBriefLoading(false);
+      }
+    },
+    [word],
+  );
+
   const handleGetExplanation = async () => {
-    if (exp) {
+    if (detail || brief) {
       setExpand((current) => !current);
       return;
     }
     setLoading(true);
+    setActiveMode("detail");
     try {
-      const text = await getExplanationAction(word);
-      setExp(text);
-      setExpand(true);
-    } catch {
-      setExp(`请求失败`);
+      await requestDetail();
     } finally {
       setLoading(false);
     }
-    setLoading(false);
   };
 
   const handleRegenerate = async () => {
     setRegenerating(true);
     try {
-      const text = await getExplanationAction(word, { force: true });
-      setExp(text);
-      setExpand(true);
-    } catch {
-      setExp("请求失败");
+      if (activeMode === "brief") {
+        await requestBrief({ force: true });
+      } else {
+        await requestDetail({ force: true });
+      }
     } finally {
       setRegenerating(false);
+    }
+  };
+
+  const handleModeChange = async (mode: WordCardMode) => {
+    setActiveMode(mode);
+    if (mode === "brief" && !brief && !briefLoading) {
+      await requestBrief();
+    }
+    if (mode === "detail" && !detail && !detailLoading) {
+      await requestDetail();
     }
   };
 
@@ -60,54 +112,58 @@ export const ContextLine: React.FC<{ word: ILuluWord }> = ({ word }) => {
         <Loader className="animate-spin mt-2 text-blue-500" size={16}></Loader>
       )}
       <div>
-        {!loading && exp && expand && (
+        {!loading && (detail || brief) && expand && (
           <>
             <div className="hidden md:block mt-5 text-gray-500 space-y-3">
-              <Markdown>{exp}</Markdown>
-              <button
-                type="button"
-                onClick={handleRegenerate}
-                disabled={regenerating}
-                className="text-xs uppercase tracking-[0.18em] text-gray-500 hover:text-gray-800 disabled:opacity-50"
-              >
-                {regenerating ? "GENERATING..." : "REGENERATE"}
-              </button>
+              <WordCardPanel
+                wordText={word.uuid}
+                phon={word.phon}
+                contextLine={stripHtml(word.context.line)}
+                activeMode={activeMode}
+                onModeChange={handleModeChange}
+                brief={{
+                  label: "简解",
+                  content: brief,
+                  loading:
+                    briefLoading ||
+                    (activeMode === "brief" && (loading || regenerating)),
+                  onRegenerate: handleRegenerate,
+                }}
+                detail={{
+                  label: "详解",
+                  content: detail,
+                  loading:
+                    detailLoading ||
+                    (activeMode === "detail" && (loading || regenerating)),
+                  onRegenerate: handleRegenerate,
+                }}
+                className="text-[color:var(--foreground)]"
+              />
             </div>
             <div className="md:hidden">
-              <MobileSheet
+              <WordCardSheet
                 open={expand}
                 onClose={handleClose}
-                ariaLabel="Close explanation"
-                panelClassName="story-card"
-                bodyClassName="px-5 py-4 space-y-3 text-[color:var(--foreground)] scrollbar-hide"
-                header={
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-semibold tracking-wide text-[color:var(--text-muted)]">
-                      {word.uuid}
-                    </span>
-                    <button
-                      type="button"
-                      aria-label="Close"
-                      onClick={handleClose}
-                      className="text-[color:var(--text-muted)] hover:text-[color:var(--foreground)]"
-                    >
-                      <X size={18} />
-                    </button>
-                  </div>
-                }
-                footer={
-                  <button
-                    type="button"
-                    onClick={handleRegenerate}
-                    disabled={regenerating}
-                    className="text-xs uppercase tracking-[0.18em] text-[color:var(--text-muted)] hover:text-[color:var(--foreground)] disabled:opacity-50"
-                  >
-                    {regenerating ? "GENERATING..." : "REGENERATE"}
-                  </button>
-                }
-              >
-                <Markdown>{exp}</Markdown>
-              </MobileSheet>
+                wordText={word.uuid}
+                phon={word.phon}
+                contextLine={stripHtml(word.context.line)}
+                activeMode={activeMode}
+                onModeChange={handleModeChange}
+                brief={{
+                  label: "简解",
+                  content: brief,
+                  loading:
+                    briefLoading || (activeMode === "brief" && regenerating),
+                  onRegenerate: handleRegenerate,
+                }}
+                detail={{
+                  label: "详解",
+                  content: detail,
+                  loading:
+                    detailLoading || (activeMode === "detail" && regenerating),
+                  onRegenerate: handleRegenerate,
+                }}
+              />
             </div>
           </>
         )}

--- a/src/app/words/[slug]/components/daily-story.tsx
+++ b/src/app/words/[slug]/components/daily-story.tsx
@@ -5,12 +5,17 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { ILuluWord } from "@/lib/words/types";
 import {
   generateSpeech,
+  getExplanationAction,
   getFreeWordCardAction,
   getWordCardAction,
   translateStoryAction,
 } from "@/app/words/[slug]/actions";
 import Markdown from "react-markdown";
-import { MobileSheet } from "@/components/MobileSheet";
+import {
+  WordCardPanel,
+  type WordCardMode,
+} from "@/app/words/[slug]/components/word-card-panel";
+import { WordCardSheet } from "@/app/words/[slug]/components/word-card-sheet";
 
 interface DailyStoryProps {
   story: string;
@@ -24,8 +29,11 @@ interface PopoverState {
   y: number;
   isMobile: boolean;
   open: boolean;
-  content?: string;
-  loading?: boolean;
+  mode: WordCardMode;
+  briefContent?: string;
+  detailContent?: string;
+  briefLoading?: boolean;
+  detailLoading?: boolean;
   audioSrc?: string;
   audioLoading?: boolean;
 }
@@ -147,7 +155,7 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
     [translation],
   );
 
-  const requestWordCard = async (
+  const requestBriefCard = async (
     wordText: string,
     word: ILuluWord | undefined,
     options?: { force?: boolean },
@@ -155,6 +163,13 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
     return word
       ? getWordCardAction(word, story, options)
       : getFreeWordCardAction(wordText, story, options);
+  };
+
+  const requestDetailCard = async (
+    word: ILuluWord,
+    options?: { force?: boolean },
+  ) => {
+    return getExplanationAction(word, options);
   };
 
   const handleSelect = async (
@@ -182,12 +197,14 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
       y: rect.bottom,
       isMobile,
       open: true,
-      loading: true,
+      mode: "brief",
+      briefLoading: true,
+      detailLoading: false,
       audioLoading: true,
     });
 
     try {
-      const contentPromise = requestWordCard(wordText, word);
+      const contentPromise = requestBriefCard(wordText, word);
       const audioPromise = word
         ? Promise.resolve(`/api/speech/${wordText}`)
         : generateSpeech(wordText).then(
@@ -201,8 +218,8 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
         if (!current || current.wordText !== wordText) return current;
         return {
           ...current,
-          content,
-          loading: false,
+          briefContent: content,
+          briefLoading: false,
           audioSrc,
           audioLoading: false,
         };
@@ -212,8 +229,8 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
         if (!current || current.wordText !== wordText) return current;
         return {
           ...current,
-          content: "生成失败，请重试。",
-          loading: false,
+          briefContent: "生成失败，请重试。",
+          briefLoading: false,
           audioLoading: false,
         };
       });
@@ -236,23 +253,38 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
 
   const handleRegenerateCard = async () => {
     if (!popover) return;
-    const { wordText, word } = popover;
+    const { wordText, word, mode } = popover;
+    if (mode === "detail" && !word) return;
     setPopover((current) => {
       if (!current) return current;
       return {
         ...current,
-        loading: true,
+        briefLoading: mode === "brief" ? true : current.briefLoading,
+        detailLoading: mode === "detail" ? true : current.detailLoading,
       };
     });
 
     try {
-      const content = await requestWordCard(wordText, word, { force: true });
+      if (mode === "detail") {
+        if (!word) return;
+        const content = await requestDetailCard(word, { force: true });
+        setPopover((current) => {
+          if (!current || current.wordText !== wordText) return current;
+          return {
+            ...current,
+            detailContent: content,
+            detailLoading: false,
+          };
+        });
+        return;
+      }
+      const content = await requestBriefCard(wordText, word, { force: true });
       setPopover((current) => {
         if (!current || current.wordText !== wordText) return current;
         return {
           ...current,
-          content,
-          loading: false,
+          briefContent: content,
+          briefLoading: false,
         };
       });
     } catch {
@@ -260,10 +292,66 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
         if (!current || current.wordText !== wordText) return current;
         return {
           ...current,
-          content: "生成失败，请重试。",
-          loading: false,
+          briefContent: mode === "brief" ? "生成失败，请重试。" : current.briefContent,
+          detailContent:
+            mode === "detail" ? "生成失败，请重试。" : current.detailContent,
+          briefLoading: false,
+          detailLoading: false,
         };
       });
+    }
+  };
+
+  const handleModeChange = async (mode: WordCardMode) => {
+    if (!popover) return;
+    if (mode === popover.mode) return;
+    setPopover((current) => {
+      if (!current) return current;
+      return { ...current, mode };
+    });
+    if (mode === "detail" && popover.word && !popover.detailContent) {
+      setPopover((current) => {
+        if (!current) return current;
+        return { ...current, detailLoading: true };
+      });
+      try {
+        const content = await requestDetailCard(popover.word);
+        setPopover((current) => {
+          if (!current) return current;
+          return { ...current, detailContent: content, detailLoading: false };
+        });
+      } catch {
+        setPopover((current) => {
+          if (!current) return current;
+          return {
+            ...current,
+            detailContent: "生成失败，请重试。",
+            detailLoading: false,
+          };
+        });
+      }
+    }
+    if (mode === "brief" && !popover.briefContent) {
+      setPopover((current) => {
+        if (!current) return current;
+        return { ...current, briefLoading: true };
+      });
+      try {
+        const content = await requestBriefCard(popover.wordText, popover.word);
+        setPopover((current) => {
+          if (!current) return current;
+          return { ...current, briefContent: content, briefLoading: false };
+        });
+      } catch {
+        setPopover((current) => {
+          if (!current) return current;
+          return {
+            ...current,
+            briefContent: "生成失败，请重试。",
+            briefLoading: false,
+          };
+        });
+      }
     }
   };
 
@@ -416,106 +504,81 @@ export const DailyStory = ({ story, words }: DailyStoryProps) => {
             />
           )}
           {popover.isMobile ? (
-            <MobileSheet
-              open={popover.open}
-              onClose={closePopover}
-              ariaLabel="Close word card"
-              panelClassName="story-card"
-              bodyClassName="px-5 py-4 space-y-4 text-[color:var(--foreground)] scrollbar-hide"
-              footer={
-                <button
-                  type="button"
-                  onClick={handleRegenerateCard}
-                  disabled={popover.loading}
-                  className="text-xs uppercase tracking-[0.18em] story-muted-action disabled:opacity-50"
-                >
-                  {popover.loading ? "GENERATING..." : "REGENERATE"}
-                </button>
-              }
-            >
-              {popover.word?.context.line && (
-                <div className="border-b border-dashed border-[color:var(--border-subtle)] pb-3 text-sm text-[color:var(--text-muted)]">
-                  <Markdown>{`> ${stripHtml(popover.word.context.line)}`}</Markdown>
-                </div>
-              )}
-              <div className="flex items-center justify-between gap-3">
-                {popover.word?.phon && (
-                  <div
-                    className="text-sm text-[color:var(--text-muted)]"
-                    dangerouslySetInnerHTML={{ __html: popover.word.phon }}
-                  />
-                )}
-                <button
-                  type="button"
-                  onClick={handlePlay}
-                  disabled={popover.audioLoading || !popover.audioSrc}
-                  className="text-sm font-medium text-[color:var(--accent-warm)] hover:opacity-80 disabled:opacity-50"
-                >
-                  {popover.audioLoading ? "生成中…" : "播放发音"}
-                </button>
-              </div>
-              {popover.loading ? (
-                <span className="text-sm text-[color:var(--text-muted)]">
-                  生成中…
-                </span>
-              ) : (
-                <Markdown>{popover.content || ""}</Markdown>
-              )}
+            <>
+              <WordCardSheet
+                open={popover.open}
+                onClose={closePopover}
+                wordText={popover.wordText}
+                phon={popover.word?.phon}
+                contextLine={
+                  popover.word?.context.line
+                    ? stripHtml(popover.word.context.line)
+                    : undefined
+                }
+                activeMode={popover.mode}
+                onModeChange={handleModeChange}
+                brief={{
+                  label: "简解",
+                  content: popover.briefContent,
+                  loading: popover.briefLoading,
+                  onRegenerate: handleRegenerateCard,
+                }}
+                detail={{
+                  label: "详解",
+                  content: popover.detailContent,
+                  loading: popover.detailLoading,
+                  available: Boolean(popover.word),
+                  onRegenerate: handleRegenerateCard,
+                }}
+                audio={{
+                  src: popover.audioSrc,
+                  loading: popover.audioLoading,
+                  onPlay: handlePlay,
+                }}
+              />
               {popover.audioSrc && (
                 <audio ref={audioRef} src={popover.audioSrc} />
               )}
-            </MobileSheet>
+            </>
           ) : (
             <div
               className="z-50 fixed story-popover-panel"
               style={{
                 top: popover.y + 8,
                 left: popover.x,
-                width: 280,
+                width: 300,
               }}
             >
               <div className="story-card rounded-2xl p-5 shadow-lg">
-                <div className="flex justify-between gap-4 items-center">
-                  <div>
-                    <h3 className="text-xl font-semibold text-foreground">
-                      {popover.wordText}
-                    </h3>
-                    {popover.word?.phon && (
-                      <div
-                        className="mt-2 text-sm text-[color:var(--text-muted)]"
-                        dangerouslySetInnerHTML={{ __html: popover.word.phon }}
-                      />
-                    )}
-                  </div>
-                  <button
-                    type="button"
-                    onClick={handlePlay}
-                    disabled={popover.audioLoading || !popover.audioSrc}
-                    className="text-sm font-medium text-[color:var(--accent-warm)] hover:opacity-80 disabled:opacity-50"
-                  >
-                    {popover.audioLoading ? "生成中…" : "播放发音"}
-                  </button>
-                </div>
-
-                <div className="mt-4 text-[color:var(--foreground)]">
-                  {popover.loading ? (
-                    <span className="text-sm text-[color:var(--text-muted)]">
-                      生成中…
-                    </span>
-                  ) : (
-                    <Markdown>{popover.content || ""}</Markdown>
-                  )}
-                </div>
-                <div className="mt-4 flex items-center justify-between gap-3">
-                  <button
-                    type="button"
-                    onClick={handleRegenerateCard}
-                    disabled={popover.loading}
-                    className="text-xs uppercase tracking-[0.18em] story-muted-action disabled:opacity-50"
-                  >
-                    {popover.loading ? "GENERATING..." : "REGENERATE"}
-                  </button>
-                </div>
+                <WordCardPanel
+                  wordText={popover.wordText}
+                  phon={popover.word?.phon}
+                  contextLine={
+                    popover.word?.context.line
+                      ? stripHtml(popover.word.context.line)
+                      : undefined
+                  }
+                  activeMode={popover.mode}
+                  onModeChange={handleModeChange}
+                  brief={{
+                    label: "简解",
+                    content: popover.briefContent,
+                    loading: popover.briefLoading,
+                    onRegenerate: handleRegenerateCard,
+                  }}
+                  detail={{
+                    label: "详解",
+                    content: popover.detailContent,
+                    loading: popover.detailLoading,
+                    available: Boolean(popover.word),
+                    onRegenerate: handleRegenerateCard,
+                  }}
+                  audio={{
+                    src: popover.audioSrc,
+                    loading: popover.audioLoading,
+                    onPlay: handlePlay,
+                  }}
+                />
                 {popover.audioSrc && (
                   <audio ref={audioRef} src={popover.audioSrc} />
                 )}

--- a/src/app/words/[slug]/components/word-card-panel.tsx
+++ b/src/app/words/[slug]/components/word-card-panel.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import Markdown from "react-markdown";
+
+export type WordCardMode = "brief" | "detail";
+
+interface WordCardContent {
+  label: string;
+  content?: string;
+  loading?: boolean;
+  available?: boolean;
+  onRegenerate?: () => void;
+}
+
+interface WordCardAudio {
+  src?: string;
+  loading?: boolean;
+  onPlay?: () => void;
+}
+
+interface WordCardPanelProps {
+  wordText: string;
+  phon?: string;
+  contextLine?: string;
+  activeMode: WordCardMode;
+  onModeChange: (mode: WordCardMode) => void;
+  brief: WordCardContent;
+  detail: WordCardContent;
+  audio?: WordCardAudio;
+  showTitle?: boolean;
+  className?: string;
+}
+
+const tabBaseClass =
+  "px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.2em] rounded-full transition";
+
+export const WordCardPanel = ({
+  wordText,
+  phon,
+  contextLine,
+  activeMode,
+  onModeChange,
+  brief,
+  detail,
+  audio,
+  showTitle = true,
+  className = "",
+}: WordCardPanelProps) => {
+  const activeContent = activeMode === "brief" ? brief : detail;
+  const briefAvailable = brief.available ?? true;
+  const detailAvailable = detail.available ?? true;
+
+  return (
+    <div className={`space-y-4 text-[color:var(--foreground)] ${className}`}>
+      {showTitle && (
+        <div className="space-y-2">
+          <div>
+            <h3 className="text-xl font-semibold text-foreground">{wordText}</h3>
+            {phon && (
+              <div
+                className="mt-2 text-sm text-[color:var(--text-muted)]"
+                dangerouslySetInnerHTML={{ __html: phon }}
+              />
+            )}
+          </div>
+        </div>
+      )}
+
+      {contextLine && (
+        <div className="border-b border-dashed border-[color:var(--border-subtle)] pb-3 text-sm text-[color:var(--text-muted)]">
+          <Markdown>{`> ${contextLine}`}</Markdown>
+        </div>
+      )}
+
+      <div className="inline-flex items-center gap-1 rounded-full border border-[color:var(--border-subtle)] p-1 text-[color:var(--text-muted)]">
+        <button
+          type="button"
+          onClick={() => briefAvailable && onModeChange("brief")}
+          disabled={!briefAvailable}
+          className={`${tabBaseClass} ${
+            activeMode === "brief"
+              ? "bg-[color:var(--foreground)] text-[color:var(--background)]"
+              : "text-[color:var(--text-muted)] hover:text-[color:var(--foreground)]"
+          } ${!briefAvailable ? "opacity-40 cursor-not-allowed" : ""}`}
+        >
+          {brief.label}
+        </button>
+        <button
+          type="button"
+          onClick={() => detailAvailable && onModeChange("detail")}
+          disabled={!detailAvailable}
+          className={`${tabBaseClass} ${
+            activeMode === "detail"
+              ? "bg-[color:var(--foreground)] text-[color:var(--background)]"
+              : "text-[color:var(--text-muted)] hover:text-[color:var(--foreground)]"
+          } ${!detailAvailable ? "opacity-40 cursor-not-allowed" : ""}`}
+        >
+          {detail.label}
+        </button>
+      </div>
+
+      <div className="min-h-[88px] text-[color:var(--foreground)]">
+        {activeContent.loading ? (
+          <span className="text-sm text-[color:var(--text-muted)]">生成中…</span>
+        ) : (
+          <Markdown>{activeContent.content || ""}</Markdown>
+        )}
+      </div>
+
+      {(audio?.onPlay || activeContent.onRegenerate) && (
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          {audio?.onPlay && (
+            <button
+              type="button"
+              onClick={audio.onPlay}
+              disabled={audio.loading || !audio.src}
+              className="text-sm font-medium text-[color:var(--accent-warm)] hover:opacity-80 disabled:opacity-50"
+            >
+              {audio.loading ? "生成中…" : "播放发音"}
+            </button>
+          )}
+          {activeContent.onRegenerate && (
+            <button
+              type="button"
+              onClick={activeContent.onRegenerate}
+              disabled={activeContent.loading}
+              className="text-xs uppercase tracking-[0.18em] story-muted-action disabled:opacity-50"
+            >
+              {activeContent.loading ? "GENERATING..." : "REGENERATE"}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/app/words/[slug]/components/word-card-sheet.tsx
+++ b/src/app/words/[slug]/components/word-card-sheet.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { X } from "lucide-react";
+import { MobileSheet } from "@/components/MobileSheet";
+import {
+  WordCardPanel,
+  type WordCardMode,
+} from "@/app/words/[slug]/components/word-card-panel";
+
+interface WordCardSheetProps {
+  open: boolean;
+  onClose: () => void;
+  wordText: string;
+  phon?: string;
+  contextLine?: string;
+  activeMode: WordCardMode;
+  onModeChange: (mode: WordCardMode) => void;
+  brief: {
+    label: string;
+    content?: string;
+    loading?: boolean;
+    onRegenerate?: () => void;
+  };
+  detail: {
+    label: string;
+    content?: string;
+    loading?: boolean;
+    available?: boolean;
+    onRegenerate?: () => void;
+  };
+  audio?: {
+    src?: string;
+    loading?: boolean;
+    onPlay?: () => void;
+  };
+}
+
+export const WordCardSheet = ({
+  open,
+  onClose,
+  wordText,
+  phon,
+  contextLine,
+  activeMode,
+  onModeChange,
+  brief,
+  detail,
+  audio,
+}: WordCardSheetProps) => {
+  return (
+    <MobileSheet
+      open={open}
+      onClose={onClose}
+      ariaLabel="Close word card"
+      panelClassName="story-card"
+      bodyClassName="px-5 py-4 space-y-4 text-[color:var(--foreground)] scrollbar-hide"
+      header={
+        <div className="flex items-center justify-between">
+          <div>
+            <span className="text-sm font-semibold tracking-wide text-[color:var(--text-muted)]">
+              {wordText}
+            </span>
+            {phon && (
+              <div
+                className="mt-2 text-xs text-[color:var(--text-muted)]"
+                dangerouslySetInnerHTML={{ __html: phon }}
+              />
+            )}
+          </div>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="text-[color:var(--text-muted)] hover:text-[color:var(--foreground)]"
+          >
+            <X size={18} />
+          </button>
+        </div>
+      }
+    >
+      <WordCardPanel
+        wordText={wordText}
+        contextLine={contextLine}
+        activeMode={activeMode}
+        onModeChange={onModeChange}
+        brief={brief}
+        detail={detail}
+        audio={audio}
+        showTitle={false}
+      />
+    </MobileSheet>
+  );
+};


### PR DESCRIPTION
### Motivation
- Provide a single reusable UI for the mobile half-screen word card so the story popover and word page use the same layout and behavior.
- Reduce duplication by extracting the common rendering (title, phonetics, context, brief/detail toggle, regen/audio controls) into shared components.
- Ensure consistent lazy-loading and per-mode loading state for `brief`/`detail` explanations across views.

### Description
- Added a reusable `WordCardPanel` component (`src/app/words/[slug]/components/word-card-panel.tsx`) that renders the title/phonetics, context quote, `brief`/`detail` tabs, content area, regeneration button, and optional audio play button.
- Added a `WordCardSheet` mobile wrapper (`src/app/words/[slug]/components/word-card-sheet.tsx`) that embeds `WordCardPanel` inside the existing `MobileSheet` layout for the half-screen experience.
- Replaced inline mobile sheet UI in `src/app/words/[slug]/components/context-line.tsx` and `src/app/words/[slug]/components/daily-story.tsx` with `WordCardSheet`, and kept the desktop popover rendering `WordCardPanel` directly for consistency.
- Refactored data/loading logic: introduced per-mode state and loaders (`brief` vs `detail`), `requestBrief`/`requestDetail` helpers, and a `handleModeChange` flow so switching modes lazily fetches the selected content while preserving audio generation/playback behavior.

### Testing
- Started the dev server with `pnpm dev` and confirmed Next reported ready (server started; Google Fonts download warnings occurred in this environment).
- Ran a Playwright script to open `http://127.0.0.1:3000/words/2024-01-01/story` and capture a screenshot of the updated story word card popover, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975e30dd0f08333845f8b918c221f62)