### PR TITLE
fix(words): fix crash when playing audio in word card

### DIFF
--- a/src/app/words/[slug]/components/word-card-panel.tsx
+++ b/src/app/words/[slug]/components/word-card-panel.tsx
@@ -68,7 +68,7 @@ export const WordCardPanel = ({
 
   const handlePlay = () => {
     if (!canPlayAudio) return;
-    audio.onPlay?.();
+    audio?.onPlay?.();
     if (resolvedAudioSrc && audioRef.current) {
       audioRef.current.src = resolvedAudioSrc;
       audioRef.current.play();


### PR DESCRIPTION
Guard the audio object before invoking onPlay to avoid accessing a property of undefined. Previously calling audio.onPlay?.() could throw a TypeError when audio was undefined; adding optional chaining on audio prevents the runtime error and ensures safe playback handling.