### PR TITLE
Adjust mobile sheet height and improve mobile scroll locking

### DIFF
--- a/src/components/MobileSheet.tsx
+++ b/src/components/MobileSheet.tsx
@@ -26,7 +26,7 @@ export const MobileSheet = ({
   footer,
   panelClassName = "",
   bodyClassName = "",
-  heightClassName = "h-[85vh]",
+  heightClassName = "h-[65vh]",
 }: MobileSheetProps) => {
   const [mounted, setMounted] = useState(open);
   const [active, setActive] = useState(open);
@@ -48,13 +48,30 @@ export const MobileSheet = ({
   useEffect(() => {
     if (!open) return undefined;
     const { body, documentElement } = document;
+    const scrollY = window.scrollY;
     const previousBodyOverflow = body.style.overflow;
+    const previousBodyPosition = body.style.position;
+    const previousBodyTop = body.style.top;
+    const previousBodyWidth = body.style.width;
+    const previousBodyOverscroll = body.style.overscrollBehavior;
     const previousHtmlOverflow = documentElement.style.overflow;
+    const previousHtmlOverscroll = documentElement.style.overscrollBehavior;
     body.style.overflow = "hidden";
+    body.style.position = "fixed";
+    body.style.top = `-${scrollY}px`;
+    body.style.width = "100%";
+    body.style.overscrollBehavior = "none";
     documentElement.style.overflow = "hidden";
+    documentElement.style.overscrollBehavior = "none";
     return () => {
       body.style.overflow = previousBodyOverflow;
+      body.style.position = previousBodyPosition;
+      body.style.top = previousBodyTop;
+      body.style.width = previousBodyWidth;
+      body.style.overscrollBehavior = previousBodyOverscroll;
       documentElement.style.overflow = previousHtmlOverflow;
+      documentElement.style.overscrollBehavior = previousHtmlOverscroll;
+      window.scrollTo(0, scrollY);
     };
   }, [open]);
 


### PR DESCRIPTION
### Motivation

- Standardize the half-screen mobile sheet height to 65vh so half-screen panels have a consistent height across the app.
- Prevent background scrolling (scroll-through / overscroll) on mobile when a sheet is open to stop unintended interaction with content behind the sheet.

### Description

- Change the default `heightClassName` for `MobileSheet` from `h-[85vh]` to `h-[65vh]` in `src/components/MobileSheet.tsx`.
- Add robust scroll locking when the sheet is open by saving `window.scrollY`, setting `body.style.position` to `fixed` with `top` set to the negative scroll position, forcing `width: 100%`, and setting `overscrollBehavior = "none"` on `body` and `documentElement`.
- Restore previous `body`/`html` style values and call `window.scrollTo(0, scrollY)` when the sheet closes to preserve the original scroll position.
- Keep the existing open/close transition behavior and preserve the `panelClassName` / `bodyClassName` extension points used by callers like `WordCardSheet`.

### Testing

- Ran `pnpm run lint`, which completed but reported an existing unused-import warning in `src/app/words/[slug]/components/daily-story.tsx` (unrelated to this change).
- Ran `pnpm run typecheck`, which succeeded with no type errors.
- Started the dev server with `pnpm exec next dev` and visited a words page via an automated Playwright script to capture a screenshot, and the app compiled and served the page despite Google Fonts fetch retries (fonts fell back but compilation succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976d4b730a88333bbe7ef43ad07bdb3)