### PR TITLE
feat(words): add feeds infinite-scroll and daily sections

### DIFF
--- a/src/app/api/words/feed/route.ts
+++ b/src/app/api/words/feed/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { WordsService } from "@/lib/words";
+import { getDailyStory } from "@/lib/words/story";
+
+export const dynamic = "force-dynamic";
+
+const pickRandomSlug = (slugs: string[]) => {
+  if (slugs.length === 0) return null;
+  const rand = crypto.getRandomValues(new Uint32Array(1))[0] / 2 ** 32;
+  const index = Math.floor(rand * slugs.length);
+  return slugs[index] ?? null;
+};
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const exclude = new Set(
+    (searchParams.get("exclude") || "")
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean),
+  );
+
+  const slugs = await WordsService.getWordsGroupKeys();
+  const candidates = slugs.filter((slug) => !exclude.has(slug));
+  const pool = candidates.length > 0 ? candidates : slugs;
+  const slug = pickRandomSlug(pool);
+
+  if (!slug) {
+    return NextResponse.json({ error: "no_data" }, { status: 404 });
+  }
+
+  const words = await WordsService.getWordsByDate(slug);
+  const story = await getDailyStory(words, slug);
+  return NextResponse.json({ slug, words, story });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -242,6 +242,70 @@ body {
   }
 }
 
+.feeds-page {
+  min-height: 100vh;
+  background: var(--background);
+}
+
+.feed-track {
+  height: 100vh;
+  overflow-y: auto;
+  scroll-snap-type: y mandatory;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+}
+
+.feed-slice {
+  display: grid;
+  grid-template-columns: 1fr;
+}
+
+.feed-item {
+  min-height: 100vh;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+  display: flex;
+  align-items: stretch;
+}
+
+.feed-panel {
+  width: 100%;
+  padding: 24px 16px;
+}
+
+.feed-panel--story .story-shell {
+  padding: 0;
+}
+
+.feed-item--story .story-page {
+  min-height: 100%;
+}
+
+.feed-empty {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+.feed-sentinel {
+  min-height: 40vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  scroll-snap-align: end;
+}
+
+@media (min-width: 768px) {
+  .feed-panel {
+    padding: 32px;
+  }
+}
+
 /* Custom animations for homepage */
 @keyframes fade-in-up {
   from {

--- a/src/app/words/[slug]/components/daily-story-section.tsx
+++ b/src/app/words/[slug]/components/daily-story-section.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import type { ILuluWord } from "@/lib/words/types";
+import { DailyStory } from "@/app/words/[slug]/components/daily-story";
+import { StoryActions } from "@/app/words/[slug]/story/story-actions";
+
+interface DailyStorySectionProps {
+  slug: string;
+  story: string;
+  words: ILuluWord[];
+  showBackLink?: boolean;
+  showActions?: boolean;
+  className?: string;
+}
+
+const buildClassName = (base: string, extra?: string) =>
+  extra ? `${base} ${extra}` : base;
+
+export const DailyStorySection = ({
+  slug,
+  story,
+  words,
+  showBackLink = true,
+  showActions = true,
+  className,
+}: DailyStorySectionProps) => {
+  return (
+    <div className={buildClassName("story-page", className)}>
+      <div className="story-shell max-w-[980px] mx-auto space-y-6">
+        <div className="space-y-3">
+          <div className="story-kicker">Daily Words Dispatch</div>
+          <h1 className="story-headline">{slug} Daily Story</h1>
+          {showActions && <StoryActions slug={slug} />}
+          <div className="story-rule" />
+        </div>
+
+        {story ? (
+          <DailyStory story={story} words={words} />
+        ) : (
+          <div className="text-gray-500">暂无可用单词。</div>
+        )}
+
+        {showBackLink && (
+          <div className="pt-6">
+            <Link
+              className="story-backlink"
+              href={`/words/${slug}`}
+            >
+              返回单词页
+            </Link>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/app/words/[slug]/components/daily-story.tsx
+++ b/src/app/words/[slug]/components/daily-story.tsx
@@ -8,7 +8,6 @@ import {
   getWordCardBundleAction,
   translatePassageAction,
 } from "@/app/words/[slug]/actions";
-import Markdown from "react-markdown";
 import {
   WordCardPanel,
   type WordCardMode,

--- a/src/app/words/[slug]/components/daily-words-section.tsx
+++ b/src/app/words/[slug]/components/daily-words-section.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Link from "next/link";
+import type { ILuluWord } from "@/lib/words/types";
+import { ContextLine } from "@/app/words/[slug]/components/context-line";
+import { Index } from "@/app/words/[slug]/components/word";
+
+interface DailyWordsSectionProps {
+  slug: string;
+  words: ILuluWord[];
+  showStoryLink?: boolean;
+  showNextLink?: boolean;
+  nextSlug?: string | null;
+  className?: string;
+  title?: string;
+}
+
+const buildClassName = (base: string, extra?: string) =>
+  extra ? `${base} ${extra}` : base;
+
+export const DailyWordsSection = ({
+  slug,
+  words,
+  showStoryLink = true,
+  showNextLink = false,
+  nextSlug,
+  className,
+  title,
+}: DailyWordsSectionProps) => {
+  return (
+    <div className={buildClassName("words-section", className)}>
+      <div className="max-w-[900px] mx-auto">
+        <div className="flex items-center justify-between mb-4">
+          <h1 className="text-3xl font-medium font-display text-foreground leading-tight tracking-tight mt-0">
+            {title ?? `${slug} Daily Words`}
+          </h1>
+          {showStoryLink && (
+            <Link
+              className="text-sm text-orange-500 hover:text-orange-600 underline underline-offset-4"
+              href={`/words/${slug}/story`}
+            >
+              今日短文
+            </Link>
+          )}
+        </div>
+        <div className="markdown-body">
+          {words.map((word) => (
+            <div key={word.uuid}>
+              <Index text={word.uuid} phon={word.phon} />
+              <ContextLine word={word} />
+            </div>
+          ))}
+        </div>
+        {showNextLink && nextSlug && (
+          <div className="mt-12 text-lg text-orange-400 font-semibold underline">
+            <Link
+              href={`/words/${nextSlug}`}
+            >{`> Next: ${nextSlug} Daily words`}</Link>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/app/words/[slug]/page.tsx
+++ b/src/app/words/[slug]/page.tsx
@@ -1,7 +1,5 @@
-import Link from "next/link";
 import { WordsService } from "@/lib/words";
-import { ContextLine } from "@/app/words/[slug]/components/context-line";
-import { Index } from "@/app/words/[slug]/components/word";
+import { DailyWordsSection } from "@/app/words/[slug]/components/daily-words-section";
 
 export default async function DailyWordsPage({
   params,
@@ -21,35 +19,12 @@ export default async function DailyWordsPage({
   })();
 
   return (
-    <div className="p-8">
-      <div className="max-w-[900px] mx-auto">
-        <div className="flex items-center justify-between mb-4">
-          <h1 className="text-3xl font-medium font-display text-foreground leading-tight tracking-tight mt-0">
-            {slug} Daily Words
-          </h1>
-          <Link
-            className="text-sm text-orange-500 hover:text-orange-600 underline underline-offset-4"
-            href={`/words/${slug}/story`}
-          >
-            今日短文
-          </Link>
-        </div>
-        <div className="markdown-body">
-          {dailyWords.map((word) => (
-            <div key={word.uuid}>
-              <Index text={word.uuid} phon={word.phon} />
-              <ContextLine word={word} />
-            </div>
-          ))}
-        </div>
-        {nextSlug && (
-          <div className="mt-12 text-lg text-orange-400 font-semibold underline">
-            <Link
-              href={`/words/${nextSlug}`}
-            >{`> Next: ${nextSlug} Daily words`}</Link>
-          </div>
-        )}
-      </div>
-    </div>
+    <DailyWordsSection
+      slug={slug}
+      words={dailyWords}
+      nextSlug={nextSlug}
+      showNextLink
+      className="p-8"
+    />
   );
 }

--- a/src/app/words/[slug]/story/page.tsx
+++ b/src/app/words/[slug]/story/page.tsx
@@ -1,8 +1,6 @@
 import { WordsService } from "@/lib/words";
 import { getDailyStory } from "@/lib/words/story";
-import { DailyStory } from "@/app/words/[slug]/components/daily-story";
-import { StoryActions } from "@/app/words/[slug]/story/story-actions";
-import Link from "next/link";
+import { DailyStorySection } from "@/app/words/[slug]/components/daily-story-section";
 
 export default async function DailyStoryPage({
   params,
@@ -14,30 +12,11 @@ export default async function DailyStoryPage({
   const story = await getDailyStory(dailyWords, slug);
 
   return (
-    <div className="story-page p-4 md:p-8">
-      <div className="story-shell max-w-[980px] mx-auto space-y-6">
-        <div className="space-y-3">
-          <div className="story-kicker">Daily Words Dispatch</div>
-          <h1 className="story-headline">{slug} Daily Story</h1>
-          <StoryActions slug={slug} />
-          <div className="story-rule" />
-        </div>
-
-        {story ? (
-          <DailyStory story={story} words={dailyWords} />
-        ) : (
-          <div className="text-gray-500">暂无可用单词。</div>
-        )}
-
-        <div className="pt-6">
-          <Link
-            className="story-backlink"
-            href={`/words/${slug}`}
-          >
-            返回单词页
-          </Link>
-        </div>
-      </div>
-    </div>
+    <DailyStorySection
+      slug={slug}
+      story={story}
+      words={dailyWords}
+      className="p-4 md:p-8"
+    />
   );
 }

--- a/src/app/words/feeds/feeds-client.tsx
+++ b/src/app/words/feeds/feeds-client.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ILuluWord } from "@/lib/words/types";
+import { DailyWordsSection } from "@/app/words/[slug]/components/daily-words-section";
+import { DailyStorySection } from "@/app/words/[slug]/components/daily-story-section";
+
+interface FeedItem {
+  slug: string;
+  words: ILuluWord[];
+  story: string;
+}
+
+interface FeedsClientProps {
+  initialItems: FeedItem[];
+}
+
+export const FeedsClient = ({ initialItems }: FeedsClientProps) => {
+  const [items, setItems] = useState<FeedItem[]>(initialItems);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const shownSlugs = useMemo(() => items.map((item) => item.slug), [items]);
+
+  const loadMore = useCallback(async () => {
+    if (loading || !hasMore) return;
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      params.set("exclude", shownSlugs.slice(-3).join(","));
+      const response = await fetch(`/api/words/feed?${params.toString()}`, {
+        cache: "no-store",
+      });
+      if (!response.ok) {
+        setHasMore(false);
+        return;
+      }
+      const data = (await response.json()) as FeedItem | null;
+      if (!data) {
+        setHasMore(false);
+        return;
+      }
+      setItems((prev) => [...prev, data]);
+    } catch {
+      setHasMore(false);
+    } finally {
+      setLoading(false);
+    }
+  }, [hasMore, loading, shownSlugs]);
+
+  useEffect(() => {
+    const target = sentinelRef.current;
+    if (!target) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          loadMore();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [loadMore]);
+
+  return (
+    <div className="feeds-page">
+      <div className="feed-track">
+        {items.length === 0 && (
+          <div className="feed-empty">暂无可用单词。</div>
+        )}
+        {items.map(({ slug, words, story }, index) => (
+          <div className="feed-slice" key={`${slug}-${index}`}>
+            <section className="feed-item feed-item--words">
+              <DailyWordsSection
+                slug={slug}
+                words={words}
+                showStoryLink={false}
+                className="feed-panel"
+              />
+            </section>
+            <section className="feed-item feed-item--story">
+              <DailyStorySection
+                slug={slug}
+                story={story}
+                words={words}
+                showBackLink={false}
+                showActions={false}
+                className="feed-panel feed-panel--story"
+              />
+            </section>
+          </div>
+        ))}
+        {hasMore && (
+          <div className="feed-sentinel" ref={sentinelRef}>
+            {loading ? "加载中..." : "继续滑动加载下一天"}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/app/words/feeds/page.tsx
+++ b/src/app/words/feeds/page.tsx
@@ -1,0 +1,30 @@
+import { WordsService } from "@/lib/words";
+import { getDailyStory } from "@/lib/words/story";
+import { FeedsClient } from "@/app/words/feeds/feeds-client";
+
+const FEED_DAYS = 5;
+
+const shuffleSlugs = (slugs: string[]) => {
+  const result = [...slugs];
+  for (let i = result.length - 1; i > 0; i -= 1) {
+    const rand = crypto.getRandomValues(new Uint32Array(1))[0] / 2 ** 32;
+    const j = Math.floor(rand * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+};
+
+export default async function WordsFeedsPage() {
+  const slugs = await WordsService.getWordsGroupKeys();
+  const feedSlugs = shuffleSlugs(slugs).slice(0, FEED_DAYS);
+
+  const feedItems = await Promise.all(
+    feedSlugs.map(async (slug) => {
+      const words = await WordsService.getWordsByDate(slug);
+      const story = await getDailyStory(words, slug);
+      return { slug, words, story };
+    }),
+  );
+
+  return <FeedsClient initialItems={feedItems} />;
+}


### PR DESCRIPTION
Add a feed API and client to support an infinite-scroll "daily words" feed. Introduces /api/words/feed route that returns a random day's words (with an optional exclude param), server-side helpers to build the daily story, and a FeedsClient that lazy-loads additional days via an IntersectionObserver. Also add a feeds page that preloads several days, shuffle logic for initial selection, and UI components: DailyWordsSection and DailyStorySection. Include feed-specific CSS for full-page feed layout, scroll snapping, and sentinel styling. Refactor existing daily words and story pages to reuse the new sections.

This enables a continuous reading experience across multiple days and keeps existing pages consistent by extracting shared UI into reusable components. No breaking changes.