### PR TITLE
Increase feed panel bottom padding to avoid snap-scroll clipping

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -270,7 +270,7 @@ body {
 
 .feed-panel {
   width: 100%;
-  padding: 24px 16px;
+  padding: 24px 16px max(24px, 14vh);
 }
 
 .feed-panel--story .story-shell {
@@ -302,7 +302,7 @@ body {
 
 @media (min-width: 768px) {
   .feed-panel {
-    padding: 32px;
+    padding: 32px 32px max(32px, 14vh);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent long feed content (words and story) from being clipped by the scroll-snap behavior when a feed item exceeds the viewport height.

### Description
- Update `src/app/globals.css` to add extra bottom padding to `.feed-panel` using `max(..., 14vh)` and apply the same logic in the `@media (min-width: 768px)` rule so tall content gets viewport-relative bottom spacing.

### Testing
- Ran `pnpm run lint` and `pnpm run typecheck`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976f9533bbc833388591b4df5089971)