### PR TITLE
Fix MobileSheet scroll bleed

### DIFF
--- a/src/components/MobileSheet.tsx
+++ b/src/components/MobileSheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 const TRANSITION_MS = 280;
 
@@ -30,6 +30,8 @@ export const MobileSheet = ({
 }: MobileSheetProps) => {
   const [mounted, setMounted] = useState(open);
   const [active, setActive] = useState(open);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const touchStartY = useRef<number | null>(null);
 
   useEffect(() => {
     if (open) {
@@ -75,6 +77,76 @@ export const MobileSheet = ({
     };
   }, [open]);
 
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const handleTouchStart = (event: TouchEvent) => {
+      const body = bodyRef.current;
+      if (!body) {
+        touchStartY.current = null;
+        return;
+      }
+      if (body.contains(event.target as Node)) {
+        touchStartY.current = event.touches[0]?.clientY ?? null;
+      } else {
+        touchStartY.current = null;
+      }
+    };
+
+    const handleTouchMove = (event: TouchEvent) => {
+      const body = bodyRef.current;
+      if (!body) {
+        event.preventDefault();
+        return;
+      }
+      if (!body.contains(event.target as Node)) {
+        event.preventDefault();
+        return;
+      }
+
+      const startY = touchStartY.current;
+      if (startY === null) return;
+
+      const currentY = event.touches[0]?.clientY ?? startY;
+      const delta = currentY - startY;
+      const maxScrollTop = body.scrollHeight - body.clientHeight;
+
+      if (maxScrollTop <= 0) {
+        event.preventDefault();
+        return;
+      }
+
+      if (delta > 0 && body.scrollTop <= 0) {
+        event.preventDefault();
+      }
+
+      if (delta < 0 && body.scrollTop >= maxScrollTop) {
+        event.preventDefault();
+      }
+    };
+
+    const handleWheel = (event: WheelEvent) => {
+      const body = bodyRef.current;
+      if (!body) {
+        event.preventDefault();
+        return;
+      }
+      if (!body.contains(event.target as Node)) {
+        event.preventDefault();
+      }
+    };
+
+    document.addEventListener("touchstart", handleTouchStart, { passive: true });
+    document.addEventListener("touchmove", handleTouchMove, { passive: false });
+    document.addEventListener("wheel", handleWheel, { passive: false });
+
+    return () => {
+      document.removeEventListener("touchstart", handleTouchStart);
+      document.removeEventListener("touchmove", handleTouchMove);
+      document.removeEventListener("wheel", handleWheel);
+    };
+  }, [open]);
+
   if (!mounted) return null;
 
   return (
@@ -94,7 +166,10 @@ export const MobileSheet = ({
         onClick={(event) => event.stopPropagation()}
       >
         {header && <div className="p-5 pb-1">{header}</div>}
-        <div className={`flex-1 overflow-y-auto ${bodyClassName}`}>
+        <div
+          ref={bodyRef}
+          className={`flex-1 overflow-y-auto ${bodyClassName}`}
+        >
           {children}
         </div>
         {footer && <div className="p-5 pt-4">{footer}</div>}


### PR DESCRIPTION
### Motivation

- The half-screen sheet allowed scroll chaining on touch devices so scrolling the sheet at its bounds would also scroll the feeds behind it, causing scroll bleed.
- Body/HTML overflow locking alone didn’t stop touch/wheel events from propagating when the sheet content reached its scroll limits, so the sheet needs scoped event handling.

### Description

- Added a `bodyRef` and `touchStartY` to track the sheet content element and initial touch position inside the sheet via `useRef`.
- Implemented `touchstart`, `touchmove`, and `wheel` handlers on `document` while the sheet is open to prevent default scrolling when the event target is outside the sheet or when the sheet is at its scroll bounds, and attached/detached them in a `useEffect` tied to `open`.
- Kept the existing body/HTML locking (setting `position: fixed`, `overflow: hidden`, `overscrollBehavior: none`, and restoring previous styles) and wired the sheet content element to the new handlers with `ref` on the scrolling container in `src/components/MobileSheet.tsx`.

### Testing

- Ran `pnpm run lint` and it completed with no ESLint warnings or errors.
- Ran `pnpm run typecheck` (`tsc --noEmit`) and it completed with no type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976fddab0e0833395ff4a9624d4fdf8)