### PR TITLE
feat(api): add CORS support to word card api

### DIFF
--- a/src/app/api/words/card/route.ts
+++ b/src/app/api/words/card/route.ts
@@ -3,21 +3,41 @@ import type { WordCardBundleRequest } from "@/lib/words/api-types";
 import { enforceRateLimit, requireApiKey } from "@/lib/middleware/security";
 import { getWordCardBundle } from "@/lib/words/ai-service";
 
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-API-Key",
+  "Access-Control-Max-Age": "86400",
+};
+
+const withCors = (response: NextResponse) => {
+  Object.entries(corsHeaders).forEach(([key, value]) => {
+    response.headers.set(key, value);
+  });
+  return response;
+};
+
+export async function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
 export async function POST(request: NextRequest) {
   const auth = requireApiKey(request);
   if (!auth.ok) {
-    return auth.response;
+    return withCors(auth.response);
   }
   const rateLimit = enforceRateLimit(request, auth.token);
   if (!rateLimit.ok) {
-    return rateLimit.response;
+    return withCors(rateLimit.response);
   }
 
   let payload: Partial<WordCardBundleRequest>;
   try {
     payload = (await request.json()) as typeof payload;
   } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    return withCors(
+      NextResponse.json({ error: "Invalid JSON body" }, { status: 400 }),
+    );
   }
 
   const word = typeof payload.word === "string" ? payload.word.trim() : "";
@@ -30,9 +50,11 @@ export async function POST(request: NextRequest) {
     typeof payload.maxChars === "number" ? payload.maxChars : undefined;
 
   if (!word || !source) {
-    return NextResponse.json(
-      { error: "word and sourceText/contextLine are required" },
-      { status: 400 },
+    return withCors(
+      NextResponse.json(
+        { error: "word and sourceText/contextLine are required" },
+        { status: 400 },
+      ),
     );
   }
 
@@ -41,10 +63,12 @@ export async function POST(request: NextRequest) {
     maxChars,
   });
 
-  return NextResponse.json({
-    type: "word_card_bundle",
-    context: content.context,
-    brief: content.brief,
-    detail: content.detail,
-  });
+  return withCors(
+    NextResponse.json({
+      type: "word_card_bundle",
+      context: content.context,
+      brief: content.brief,
+      detail: content.detail,
+    }),
+  );
 }


### PR DESCRIPTION
Allow cross-origin requests to the /api/words/card endpoint. Add a preflight OPTIONS handler and ensure Access-Control headers are included on all POST responses (including error cases) so external clients can call the endpoint while existing API key and rate limit checks remain enforced.