### PR TITLE
feat(words): add word storage, lulu sync and APIs

### DIFF
--- a/src/app/api/words/add/route.ts
+++ b/src/app/api/words/add/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { AddWordEntryRequest } from "@/lib/words/api-types";
+import { enforceRateLimit, requireApiKey } from "@/lib/middleware/security";
+import { insertWordEntry } from "@/lib/words/storage";
+
+export async function POST(request: NextRequest) {
+  const auth = requireApiKey(request);
+  if (!auth.ok) {
+    return auth.response;
+  }
+  const rateLimit = enforceRateLimit(request, auth.token);
+  if (!rateLimit.ok) {
+    return rateLimit.response;
+  }
+
+  let payload: Partial<AddWordEntryRequest>;
+  try {
+    payload = (await request.json()) as typeof payload;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const word = typeof payload.word === "string" ? payload.word.trim() : "";
+  const contextLine =
+    typeof payload.contextLine === "string" ? payload.contextLine.trim() : "";
+  const language =
+    typeof payload.language === "string" ? payload.language.trim() : "en";
+  const provider =
+    typeof payload.provider === "string" ? payload.provider.trim() : "manual";
+
+  if (!word || !contextLine) {
+    return NextResponse.json(
+      { error: "word and contextLine are required" },
+      { status: 400 },
+    );
+  }
+
+  const entry = await insertWordEntry({
+    word,
+    language,
+    context: contextLine,
+    brief: "",
+    detail: "",
+    contextLine,
+    provider,
+    providerPayload: null,
+  });
+
+  return NextResponse.json({
+    type: "word_entry",
+    id: entry.id,
+    word,
+    context: contextLine,
+  });
+}

--- a/src/app/api/words/card/route.ts
+++ b/src/app/api/words/card/route.ts
@@ -2,73 +2,50 @@ import { NextRequest, NextResponse } from "next/server";
 import type { WordCardBundleRequest } from "@/lib/words/api-types";
 import { enforceRateLimit, requireApiKey } from "@/lib/middleware/security";
 import { getWordCardBundle } from "@/lib/words/ai-service";
-
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-API-Key",
-  "Access-Control-Max-Age": "86400",
-};
-
-const withCors = (response: NextResponse) => {
-  Object.entries(corsHeaders).forEach(([key, value]) => {
-    response.headers.set(key, value);
-  });
-  return response;
-};
-
-export async function OPTIONS() {
-  return withCors(new NextResponse(null, { status: 204 }));
-}
+import { getWordEntryStatus } from "@/lib/words/storage";
 
 export async function POST(request: NextRequest) {
   const auth = requireApiKey(request);
   if (!auth.ok) {
-    return withCors(auth.response);
+    return auth.response;
   }
   const rateLimit = enforceRateLimit(request, auth.token);
   if (!rateLimit.ok) {
-    return withCors(rateLimit.response);
+    return rateLimit.response;
   }
 
   let payload: Partial<WordCardBundleRequest>;
   try {
     payload = (await request.json()) as typeof payload;
   } catch {
-    return withCors(
-      NextResponse.json({ error: "Invalid JSON body" }, { status: 400 }),
-    );
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
   const word = typeof payload.word === "string" ? payload.word.trim() : "";
   const sourceText =
     typeof payload.sourceText === "string" ? payload.sourceText.trim() : "";
-  const contextLine =
-    typeof payload.contextLine === "string" ? payload.contextLine.trim() : "";
-  const source = sourceText || contextLine;
   const maxChars =
     typeof payload.maxChars === "number" ? payload.maxChars : undefined;
 
-  if (!word || !source) {
-    return withCors(
-      NextResponse.json(
-        { error: "word and sourceText/contextLine are required" },
-        { status: 400 },
-      ),
+  if (!word || !sourceText) {
+    return NextResponse.json(
+      { error: "word and sourceText are required" },
+      { status: 400 },
     );
   }
 
-  const content = await getWordCardBundle(word, source, {
+  const content = await getWordCardBundle(word, sourceText, {
     force: payload.force,
     maxChars,
   });
+  const contextLine = content.context || sourceText;
+  const status = await getWordEntryStatus(word, contextLine);
 
-  return withCors(
-    NextResponse.json({
-      type: "word_card_bundle",
-      context: content.context,
-      brief: content.brief,
-      detail: content.detail,
-    }),
-  );
+  return NextResponse.json({
+    type: "word_card_bundle",
+    status,
+    context: contextLine,
+    brief: content.brief,
+    detail: content.detail,
+  });
 }

--- a/src/app/api/words/sync/route.ts
+++ b/src/app/api/words/sync/route.ts
@@ -1,0 +1,151 @@
+import { NextRequest, NextResponse } from "next/server";
+import { enforceRateLimit, requireApiKey } from "@/lib/middleware/security";
+import { getLuluWords } from "@/lib/words/lulu";
+import { insertWordEntry } from "@/lib/words/storage";
+import { getSupabaseClient } from "@/lib/supabase";
+
+type SyncPayload = {
+  provider?: string;
+  limit?: number;
+};
+
+const stripHtml = (value: string) =>
+  value.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
+
+const normalizeWord = (value: unknown) => {
+  if (typeof value !== "string") return "";
+  return stripHtml(value);
+};
+
+export async function POST(request: NextRequest) {
+  const auth = requireApiKey(request);
+  if (!auth.ok) {
+    return auth.response;
+  }
+  const rateLimit = enforceRateLimit(request, auth.token);
+  if (!rateLimit.ok) {
+    return rateLimit.response;
+  }
+
+  let payload: SyncPayload = {};
+  try {
+    payload = (await request.json()) as SyncPayload;
+  } catch {
+    payload = {};
+  }
+
+  const provider =
+    typeof payload.provider === "string" ? payload.provider.trim() : "lulu";
+  if (provider !== "lulu") {
+    return NextResponse.json({ error: "Unsupported provider" }, { status: 400 });
+  }
+
+  const supabase = getSupabaseClient();
+  const { data: job, error: jobError } = await supabase
+    .from("word_sync_jobs")
+    .insert({
+      provider,
+      status: "running",
+      started_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+
+  if (jobError) {
+    return NextResponse.json({ error: jobError.message }, { status: 500 });
+  }
+
+  const jobId = job?.id as string | undefined;
+
+  try {
+    const allWords = await getLuluWords();
+    const limit =
+      typeof payload.limit === "number" && payload.limit > 0
+        ? payload.limit
+        : undefined;
+    const words = limit ? allWords.slice(0, limit) : allWords;
+
+    const { data: existing, error: existingError } = await supabase
+      .from("word_entries")
+      .select("provider_payload")
+      .eq("provider", provider);
+
+    if (existingError) {
+      throw new Error(existingError.message);
+    }
+
+    const existingUuids = new Set<string>();
+    for (const row of existing ?? []) {
+      const payload = row.provider_payload as { uuid?: string } | null;
+      if (payload?.uuid) existingUuids.add(payload.uuid);
+    }
+
+    let inserted = 0;
+    let skipped = 0;
+
+    for (const entry of words) {
+      if (entry.uuid && existingUuids.has(entry.uuid)) {
+        skipped += 1;
+        continue;
+      }
+
+      const wordText =
+        normalizeWord(entry.word) || normalizeWord(entry.uuid) || "";
+      const contextLine = normalizeWord(entry.context?.line);
+      if (!wordText || !contextLine) {
+        skipped += 1;
+        continue;
+      }
+
+      await insertWordEntry({
+        word: wordText,
+        language: "en",
+        context: contextLine,
+        brief: "",
+        detail: "",
+        sourceText: contextLine,
+        contextLine,
+        provider,
+        providerPayload: {
+          id: entry.id,
+          uuid: entry.uuid,
+          exp: entry.exp,
+          addtime: entry.addtime,
+          phon: entry.phon,
+        },
+        createdAt: entry.addtime,
+      });
+      inserted += 1;
+    }
+
+    await supabase
+      .from("word_sync_jobs")
+      .update({
+        status: "success",
+        finished_at: new Date().toISOString(),
+      })
+      .eq("id", jobId);
+
+    return NextResponse.json({
+      type: "word_sync",
+      jobId,
+      inserted,
+      skipped,
+      total: words.length,
+    });
+  } catch (error) {
+    await supabase
+      .from("word_sync_jobs")
+      .update({
+        status: "failed",
+        finished_at: new Date().toISOString(),
+        error: error instanceof Error ? error.message : "Unknown error",
+      })
+      .eq("id", jobId);
+
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -121,12 +121,6 @@ body {
   margin: 0;
 }
 
-.story-rule {
-  height: 1px;
-  width: 100%;
-  background: var(--border-subtle);
-}
-
 .story-body {
   font-family: "Times New Roman", "Georgia", "Noto Serif", serif;
   font-size: 1.2rem;

--- a/src/app/words/[slug]/components/daily-story-section.tsx
+++ b/src/app/words/[slug]/components/daily-story-section.tsx
@@ -27,12 +27,11 @@ export const DailyStorySection = ({
 }: DailyStorySectionProps) => {
   return (
     <div className={buildClassName("story-page", className)}>
-      <div className="story-shell max-w-[980px] mx-auto space-y-6">
+      <div className="story-shell max-w-[900px] mx-auto space-y-6">
         <div className="space-y-3">
           <div className="story-kicker">Daily Words Dispatch</div>
           <h1 className="story-headline">{slug} Daily Story</h1>
           {showActions && <StoryActions slug={slug} />}
-          <div className="story-rule" />
         </div>
 
         {story ? (
@@ -43,10 +42,7 @@ export const DailyStorySection = ({
 
         {showBackLink && (
           <div className="pt-6">
-            <Link
-              className="story-backlink"
-              href={`/words/${slug}`}
-            >
+            <Link className="story-backlink" href={`/words/${slug}`}>
               返回单词页
             </Link>
           </div>

--- a/src/lib/words/api-types.ts
+++ b/src/lib/words/api-types.ts
@@ -47,3 +47,10 @@ export interface WordCardBundleRequest {
   maxChars?: number;
   force?: boolean;
 }
+
+export interface AddWordEntryRequest {
+  word: string;
+  contextLine: string;
+  language?: string;
+  provider?: string;
+}

--- a/src/lib/words/index.ts
+++ b/src/lib/words/index.ts
@@ -1,140 +1,54 @@
+import type { ILuluWord } from "./types";
 import {
-  LULU_ENDPOINT,
-  LULU_ENDPOINT_PRE,
-  SYSTEM_PROMPT,
-} from "@/lib/words/constants";
-import type { ILuluWord, IResponse } from "./types";
-import { format } from "date-fns";
-import { ai_generateText } from "@/lib/ai";
+  listWordEntriesByDate,
+  listWordEntryDates,
+  listWordTexts,
+  type WordEntryRecord,
+} from "@/lib/words/storage";
 
-const fetchWithTimeout = async (
-  input: RequestInfo | URL,
-  init: RequestInit,
-  timeoutMs = 8000,
-) => {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    return await fetch(input, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timeoutId);
-  }
+const toHTML = (wordText: string, contextLine: string) => {
+  return `<p><strong>${wordText}</strong><br/>${contextLine}</p>`;
 };
 
-/**
- * 获取生词本总数
- */
-const getWordsLength = async () => {
-  try {
-    const response = await fetchWithTimeout(LULU_ENDPOINT_PRE, {
-      headers: {
-        ["Cookie"]: process.env.LULU_COOKIE || "",
-        ["Content-Type"]: "application/json",
-      },
-      next: {
-        revalidate: 60 * 5,
-      },
-    });
-    const result = await response.json();
-    if (typeof result.recordsTotal === "number") {
-      return result.recordsTotal;
-    }
-  } catch {
-    return 0;
-  }
-};
+const toWord = (entry: WordEntryRecord): ILuluWord => {
+  const wordText = entry.wordText || "";
+  const contextLine =
+    entry.contextLine || entry.sourceText || entry.context || "";
 
-/**
- * 获取单词列表，前 25 个
- */
-const getLuLuWords = async () => {
-  try {
-    const totalLength = await getWordsLength();
-    const result = await fetchWithTimeout(`${LULU_ENDPOINT}&length=${totalLength}`, {
-      headers: {
-        ["Cookie"]: process.env.LULU_COOKIE || "",
-        ["Content-Type"]: "application/json",
-      },
-      next: { revalidate: 60 * 5 },
-    });
-
-    const parsedResult: IResponse = await result.json();
-
-    if (Array.isArray(parsedResult.data)) {
-      return parsedResult.data;
-    }
-    return [];
-  } catch {
-    return [];
-  }
-};
-
-export const getExplanation = async (word: ILuluWord) => {
-  return await ai_generateText({
-    system: SYSTEM_PROMPT,
-    prompt: `word: ${word.uuid}, context: ${word.context.line || ""}`,
-  });
-};
-
-const toHTML = (word: ILuluWord) => {
-  return `<p><strong>${word.word}</strong><br/>${word.context.line}</p>`;
-};
-
-const groupWordsByDate = async (words: ILuluWord[]) => {
-  const wordsMap = new Map<string, ILuluWord[]>();
-
-  for (const word of words) {
-    const day = format(new Date(word.addtime), "yyyy-MM-dd");
-    const wordsOfDay = wordsMap.get(day);
-    const parsedWords = { ...word, html: toHTML(word) };
-    if (wordsOfDay) {
-      wordsOfDay.push(parsedWords);
-    } else {
-      wordsMap.set(day, [parsedWords]);
-    }
-  }
-
-  return wordsMap;
+  return {
+    id: entry.id,
+    uuid: wordText,
+    word: wordText,
+    exp: "",
+    addtime: entry.createdAt,
+    context: { line: contextLine },
+    phon: "",
+    html: toHTML(wordText, contextLine),
+  };
 };
 
 export const WordsService = (() => {
-  let promise: Promise<Map<string, ILuluWord[]>>;
-
-  const check = () => {
-    if (!promise) {
-      promise = (async () => {
-        return groupWordsByDate(await getLuLuWords());
-      })();
-    }
-  };
-
-  const getAllWords = async () => {
-    check();
-    return await promise;
-  };
-
   const getWordsByDate = async (date: string) => {
-    check();
-    const wordsMap = await promise;
-    return wordsMap.get(date) ?? [];
+    const entries = await listWordEntriesByDate(date);
+    return entries.map(toWord);
   };
 
   const getWordsGroupKeys = async () => {
-    check();
-    const wordsMap = await promise;
-    return Array.from(wordsMap.keys());
+    return await listWordEntryDates();
   };
 
   const getAllWordUuids = async () => {
-    check();
-    const wordsMap = await promise;
-    const uuidSet = new Set<string>();
-    for (const wordsOfDay of wordsMap.values()) {
-      for (const word of wordsOfDay) {
-        if (word.uuid) uuidSet.add(word.uuid);
-      }
+    return await listWordTexts();
+  };
+
+  const getAllWords = async () => {
+    const dates = await listWordEntryDates();
+    const wordsMap = new Map<string, ILuluWord[]>();
+    for (const date of dates) {
+      const words = await getWordsByDate(date);
+      wordsMap.set(date, words);
     }
-    return Array.from(uuidSet);
+    return wordsMap;
   };
 
   return {

--- a/src/lib/words/lulu.ts
+++ b/src/lib/words/lulu.ts
@@ -1,0 +1,58 @@
+import { LULU_ENDPOINT, LULU_ENDPOINT_PRE } from "@/lib/words/constants";
+import type { IResponse, ILuluWord } from "@/lib/words/types";
+
+const fetchWithTimeout = async (
+  input: RequestInfo | URL,
+  init: RequestInit,
+  timeoutMs = 8000,
+) => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};
+
+const getWordsLength = async () => {
+  try {
+    const response = await fetchWithTimeout(LULU_ENDPOINT_PRE, {
+      headers: {
+        ["Cookie"]: process.env.LULU_COOKIE || "",
+        ["Content-Type"]: "application/json",
+      },
+      next: {
+        revalidate: 60 * 5,
+      },
+    });
+    const result = await response.json();
+    if (typeof result.recordsTotal === "number") {
+      return result.recordsTotal;
+    }
+  } catch {
+    return 0;
+  }
+};
+
+export const getLuluWords = async (): Promise<ILuluWord[]> => {
+  try {
+    const totalLength = await getWordsLength();
+    const result = await fetchWithTimeout(`${LULU_ENDPOINT}&length=${totalLength}`, {
+      headers: {
+        ["Cookie"]: process.env.LULU_COOKIE || "",
+        ["Content-Type"]: "application/json",
+      },
+      next: { revalidate: 60 * 5 },
+    });
+
+    const parsedResult: IResponse = await result.json();
+
+    if (Array.isArray(parsedResult.data)) {
+      return parsedResult.data;
+    }
+    return [];
+  } catch {
+    return [];
+  }
+};

--- a/src/lib/words/storage.ts
+++ b/src/lib/words/storage.ts
@@ -1,0 +1,187 @@
+import { addDays, format } from "date-fns";
+import { getSupabaseClient } from "@/lib/supabase";
+
+const WORDS_TABLE = "words";
+const ENTRIES_TABLE = "word_entries";
+
+export interface WordEntryRecord {
+  id: string;
+  wordText: string;
+  language: string;
+  sourceText: string | null;
+  contextLine: string | null;
+  context: string;
+  createdAt: string;
+}
+
+export const ensureWordId = async (word: string, language = "en") => {
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from(WORDS_TABLE)
+    .upsert(
+      {
+        text: word,
+        language,
+      },
+      { onConflict: "language,text" },
+    )
+    .select("id")
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data.id as string;
+};
+
+export const insertWordEntry = async (payload: {
+  word: string;
+  language?: string;
+  context: string;
+  brief: string;
+  detail: string;
+  sourceText?: string | null;
+  contextLine?: string | null;
+  maxChars?: number | null;
+  provider?: string;
+  providerPayload?: Record<string, unknown> | null;
+  createdAt?: string;
+}) => {
+  const wordId = await ensureWordId(payload.word, payload.language ?? "en");
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from(ENTRIES_TABLE)
+    .insert({
+      word_id: wordId,
+      context: payload.context,
+      brief: payload.brief,
+      detail: payload.detail,
+      source_text: payload.sourceText ?? null,
+      context_line: payload.contextLine ?? null,
+      max_chars: payload.maxChars ?? null,
+      provider: payload.provider ?? "manual",
+      provider_payload: payload.providerPayload ?? null,
+      ...(payload.createdAt ? { created_at: payload.createdAt } : {}),
+    })
+    .select("id, word_id, created_at")
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return {
+    id: data.id as string,
+    wordId: (data.word_id as string) || wordId,
+    createdAt: data.created_at as string,
+  };
+};
+
+export const listWordEntriesByDate = async (
+  dateSlug: string,
+): Promise<WordEntryRecord[]> => {
+  const start = new Date(`${dateSlug}T00:00:00.000Z`);
+  if (Number.isNaN(start.getTime())) {
+    throw new Error("Invalid date slug");
+  }
+  const end = addDays(start, 1);
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from(ENTRIES_TABLE)
+    .select(
+      "id, created_at, source_text, context_line, context, words ( text, language )",
+    )
+    .gte("created_at", start.toISOString())
+    .lt("created_at", end.toISOString())
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data ?? []).map((entry) => {
+    const wordRow = entry.words as { text?: string; language?: string } | null;
+    return {
+      id: entry.id as string,
+      wordText: wordRow?.text ?? "",
+      language: wordRow?.language ?? "en",
+      sourceText: (entry.source_text as string | null) ?? null,
+      contextLine: (entry.context_line as string | null) ?? null,
+      context: (entry.context as string) ?? "",
+      createdAt: entry.created_at as string,
+    };
+  });
+};
+
+export const listWordEntryDates = async (): Promise<string[]> => {
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from(ENTRIES_TABLE)
+    .select("created_at")
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const dates = new Set<string>();
+  for (const row of data ?? []) {
+    const createdAt = row.created_at as string | null;
+    if (!createdAt) continue;
+    dates.add(format(new Date(createdAt), "yyyy-MM-dd"));
+  }
+
+  return Array.from(dates).sort((a, b) => b.localeCompare(a));
+};
+
+export const listWordTexts = async (): Promise<string[]> => {
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase.from(WORDS_TABLE).select("text");
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data ?? [])
+    .map((row) => row.text as string)
+    .filter(Boolean);
+};
+
+export const getWordEntryStatus = async (
+  word: string,
+  contextLine: string,
+): Promise<"new" | "existing_same" | "existing_diff"> => {
+  const supabase = getSupabaseClient();
+  const { data: wordRow, error: wordError } = await supabase
+    .from(WORDS_TABLE)
+    .select("id")
+    .eq("text", word)
+    .maybeSingle();
+
+  if (wordError) {
+    throw new Error(wordError.message);
+  }
+
+  if (!wordRow?.id) {
+    return "new";
+  }
+
+  const { data: entries, error: entriesError } = await supabase
+    .from(ENTRIES_TABLE)
+    .select("context_line")
+    .eq("word_id", wordRow.id);
+
+  if (entriesError) {
+    throw new Error(entriesError.message);
+  }
+
+  const normalized = contextLine.trim();
+  const hasSame =
+    entries?.some((entry) => {
+      const contextLine = (entry.context_line as string | null)?.trim();
+      return contextLine === normalized;
+    }) ?? false;
+
+  return hasSame ? "existing_same" : "existing_diff";
+};


### PR DESCRIPTION
Introduce persistent word storage and external sync capabilities, and wire them into the word-card API and service.

- add src/lib/words/storage.ts: supabase-backed word/entry CRUD and helpers (ensureWordId, insertWordEntry, listWordEntriesByDate, listWordEntryDates, listWordTexts, getWordEntryStatus)
- add src/lib/words/lulu.ts: client to fetch words from lulu endpoints
- add src/app/api/words/sync/route.ts: import words from lulu, record sync jobs, dedupe by provider payload, and report inserted/skipped counts
- add src/app/api/words/add/route.ts: authenticated endpoint to insert manual word entries
- modify src/app/api/words/card/route.ts: remove legacy CORS helper, require sourceText, call getWordCardBundle, include entry status (new/existing_same/ existing_diff) in response
- refactor src/lib/words/index.ts: use storage-backed lists and map entries to ILuluWord for UI consumers; simplify WordsService methods
- add AddWordEntryRequest type to api-types

Also:
- update layout/UI: adjust story max-width and remove subtle rule usage
- remove duplicated lulu logic from words index to central lulu module

These changes centralize persistence, enable scheduled/manual syncing from the lulu provider, and let the frontend know whether a generated card would create a new entry or match existing ones.