### PR TITLE
feat(words): add paginated feeds API and infinite-scroll client

### DIFF
--- a/src/app/api/words/feed/route.ts
+++ b/src/app/api/words/feed/route.ts
@@ -4,32 +4,39 @@ import { getDailyStory } from "@/lib/words/story";
 
 export const dynamic = "force-dynamic";
 
-const pickRandomSlug = (slugs: string[]) => {
-  if (slugs.length === 0) return null;
-  const rand = crypto.getRandomValues(new Uint32Array(1))[0] / 2 ** 32;
-  const index = Math.floor(rand * slugs.length);
-  return slugs[index] ?? null;
+const parseLimit = (value: string | null, fallback: number) => {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.min(20, Math.floor(parsed));
 };
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const exclude = new Set(
-    (searchParams.get("exclude") || "")
-      .split(",")
-      .map((item) => item.trim())
-      .filter(Boolean),
-  );
+  const before = searchParams.get("before");
+  const limit = parseLimit(searchParams.get("limit"), 5);
 
   const slugs = await WordsService.getWordsGroupKeys();
-  const candidates = slugs.filter((slug) => !exclude.has(slug));
-  const pool = candidates.length > 0 ? candidates : slugs;
-  const slug = pickRandomSlug(pool);
-
-  if (!slug) {
+  if (slugs.length === 0) {
     return NextResponse.json({ error: "no_data" }, { status: 404 });
   }
 
-  const words = await WordsService.getWordsByDate(slug);
-  const story = await getDailyStory(words, slug);
-  return NextResponse.json({ slug, words, story });
+  const startIndex = before ? slugs.indexOf(before) + 1 : 0;
+  const page =
+    startIndex > 0 ? slugs.slice(startIndex, startIndex + limit) : slugs.slice(0, limit);
+
+  if (page.length === 0) {
+    return NextResponse.json({ items: [], nextCursor: null });
+  }
+
+  const items = await Promise.all(
+    page.map(async (slug) => {
+      const words = await WordsService.getWordsByDate(slug);
+      const story = await getDailyStory(words, slug);
+      return { slug, words, story };
+    }),
+  );
+
+  const nextCursor = page[page.length - 1] ?? null;
+  return NextResponse.json({ items, nextCursor });
 }

--- a/src/app/rss/words.xml/route.ts
+++ b/src/app/rss/words.xml/route.ts
@@ -1,7 +1,7 @@
 import RSS from "rss";
 import { WordsService } from "@/lib/words";
 
-export const dynamic = "auto";
+export const dynamic = "force-dynamic";
 
 /**
  * GET /rss/blog

--- a/src/app/words/feeds/feeds-client.tsx
+++ b/src/app/words/feeds/feeds-client.tsx
@@ -20,15 +20,25 @@ export const FeedsClient = ({ initialItems }: FeedsClientProps) => {
   const [loading, setLoading] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const nextCursorRef = useRef<string | null>(null);
 
-  const shownSlugs = useMemo(() => items.map((item) => item.slug), [items]);
+  const lastSlug = useMemo(() => {
+    return items.length > 0 ? items[items.length - 1]?.slug ?? null : null;
+  }, [items]);
+
+  useEffect(() => {
+    nextCursorRef.current = lastSlug;
+  }, [lastSlug]);
 
   const loadMore = useCallback(async () => {
     if (loading || !hasMore) return;
     setLoading(true);
     try {
       const params = new URLSearchParams();
-      params.set("exclude", shownSlugs.slice(-3).join(","));
+      if (nextCursorRef.current) {
+        params.set("before", nextCursorRef.current);
+      }
+      params.set("limit", "5");
       const response = await fetch(`/api/words/feed?${params.toString()}`, {
         cache: "no-store",
       });
@@ -36,18 +46,27 @@ export const FeedsClient = ({ initialItems }: FeedsClientProps) => {
         setHasMore(false);
         return;
       }
-      const data = (await response.json()) as FeedItem | null;
-      if (!data) {
+      const data = (await response.json()) as {
+        items: FeedItem[];
+        nextCursor: string | null;
+      };
+      if (!data.items.length) {
         setHasMore(false);
         return;
       }
-      setItems((prev) => [...prev, data]);
+      setItems((prev) => [...prev, ...data.items]);
+      nextCursorRef.current = data.nextCursor;
+      if (!data.nextCursor) {
+        setHasMore(false);
+      }
     } catch {
       setHasMore(false);
     } finally {
       setLoading(false);
     }
-  }, [hasMore, loading, shownSlugs]);
+  }, [hasMore, loading]);
+
+  const triggerIndex = Math.max(1, items.length - 4);
 
   useEffect(() => {
     const target = sentinelRef.current;
@@ -62,41 +81,43 @@ export const FeedsClient = ({ initialItems }: FeedsClientProps) => {
     );
     observer.observe(target);
     return () => observer.disconnect();
-  }, [loadMore]);
+  }, [loadMore, triggerIndex]);
 
   return (
     <div className="feeds-page">
       <div className="feed-track">
-        {items.length === 0 && (
-          <div className="feed-empty">暂无可用单词。</div>
-        )}
-        {items.map(({ slug, words, story }, index) => (
-          <div className="feed-slice" key={`${slug}-${index}`}>
-            <section className="feed-item feed-item--words">
-              <DailyWordsSection
-                slug={slug}
-                words={words}
-                showStoryLink={false}
-                className="feed-panel"
-              />
-            </section>
-            <section className="feed-item feed-item--story">
-              <DailyStorySection
-                slug={slug}
-                story={story}
-                words={words}
-                showBackLink={false}
-                showActions={false}
-                className="feed-panel feed-panel--story"
-              />
-            </section>
-          </div>
-        ))}
-        {hasMore && (
-          <div className="feed-sentinel" ref={sentinelRef}>
-            {loading ? "加载中..." : "继续滑动加载下一天"}
-          </div>
-        )}
+        {items.length === 0 && <div className="feed-empty">暂无可用单词。</div>}
+        {items.map(({ slug, words, story }, index) => {
+          const withSentinel = index === triggerIndex;
+          return (
+            <div className="feed-slice" key={`${slug}-${index}`}>
+              <section className="feed-item feed-item--words">
+                <DailyWordsSection
+                  slug={slug}
+                  words={words}
+                  showStoryLink={false}
+                  className="feed-panel"
+                />
+              </section>
+              <section className="feed-item feed-item--story">
+                <DailyStorySection
+                  slug={slug}
+                  story={story}
+                  words={words}
+                  showBackLink={false}
+                  showActions={false}
+                  className="feed-panel feed-panel--story"
+                />
+              </section>
+              {withSentinel && hasMore && (
+                <div className="feed-sentinel" ref={sentinelRef}>
+                  {loading ? "加载中..." : "继续滑动加载下一天"}
+                </div>
+              )}
+            </div>
+          );
+        })}
+        {!hasMore && <div className="feed-sentinel">暂无更多内容</div>}
       </div>
     </div>
   );

--- a/src/app/words/feeds/page.tsx
+++ b/src/app/words/feeds/page.tsx
@@ -4,19 +4,9 @@ import { FeedsClient } from "@/app/words/feeds/feeds-client";
 
 const FEED_DAYS = 5;
 
-const shuffleSlugs = (slugs: string[]) => {
-  const result = [...slugs];
-  for (let i = result.length - 1; i > 0; i -= 1) {
-    const rand = crypto.getRandomValues(new Uint32Array(1))[0] / 2 ** 32;
-    const j = Math.floor(rand * (i + 1));
-    [result[i], result[j]] = [result[j], result[i]];
-  }
-  return result;
-};
-
 export default async function WordsFeedsPage() {
   const slugs = await WordsService.getWordsGroupKeys();
-  const feedSlugs = shuffleSlugs(slugs).slice(0, FEED_DAYS);
+  const feedSlugs = slugs.slice(0, FEED_DAYS);
 
   const feedItems = await Promise.all(
     feedSlugs.map(async (slug) => {

--- a/src/lib/words/storage.ts
+++ b/src/lib/words/storage.ts
@@ -81,7 +81,7 @@ export const insertWordEntry = async (payload: {
 export const listWordEntriesByDate = async (
   dateSlug: string,
 ): Promise<WordEntryRecord[]> => {
-  const start = new Date(`${dateSlug}T00:00:00.000Z`);
+  const start = new Date(`${dateSlug}T00:00:00`);
   if (Number.isNaN(start.getTime())) {
     throw new Error("Invalid date slug");
   }


### PR DESCRIPTION
Introduce cursor-based pagination for /api/words/feed to return pages of items with nextCursor, and support before and limit query params. Update the feeds client to request pages (limit=5), track nextCursor, and place the intersection sentinel at a trigger index to improve infinite-scroll UX. Remove random shuffling so feed ordering is deterministic. Add parseLimit validation and cap the page size at 20.

Fix date parsing for word entries to avoid unintended timezone offset by parsing date slugs without forcing a 'Z' suffix.

Set RSS route to force-dynamic for consistent runtime behavior.