### PR TITLE
feat(daily): improve loading and optimistic navigation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -235,6 +235,28 @@ body {
   gap: 24px;
 }
 
+.daily-shell--loading {
+  justify-content: center;
+  align-items: center;
+}
+
+.daily-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: min(24vw, 120px);
+  height: min(24vw, 120px);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--accent-warm) 12%, transparent);
+}
+
+.daily-loading-icon {
+  width: 40px;
+  height: 40px;
+  color: var(--accent-warm);
+  animation: daily-spin 0.9s linear infinite;
+}
+
 .daily-progress {
   position: fixed;
   top: 0;
@@ -393,6 +415,15 @@ body {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@keyframes daily-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
   }
 }
 

--- a/src/app/words/daily/daily-task-client.tsx
+++ b/src/app/words/daily/daily-task-client.tsx
@@ -113,6 +113,7 @@ export const DailyTaskClient = ({
   const pendingReviewRef = useRef<Set<string>>(new Set());
   const masteredCardsRef = useRef<Set<string>>(new Set());
   const currentVisitOpenedRef = useRef(false);
+  const navLockRef = useRef(false);
   const [pendingVersion, setPendingVersion] = useState(0);
   const [masteredVersion, setMasteredVersion] = useState(0);
   const confettiPieces = useMemo(() => buildConfetti(), []);
@@ -289,85 +290,95 @@ export const DailyTaskClient = ({
     }
   };
 
+  const reportCard = (cardIndex: number, openedThisVisit: boolean) => {
+    void processCard(cardIndex, openedThisVisit).catch(() => undefined);
+  };
+
+  const acquireNavLock = () => {
+    if (navLockRef.current) return false;
+    navLockRef.current = true;
+    setIsProcessing(true);
+    queueMicrotask(() => {
+      navLockRef.current = false;
+      setIsProcessing(false);
+    });
+    return true;
+  };
+
   const handlePrev = () => {
     if (phase === "review" || index === 0 || isProcessing) return;
+    if (!acquireNavLock()) return;
     setIndex((current) => Math.max(0, current - 1));
   };
 
   const handleNext = async () => {
     if (!card || isProcessing) return;
-    setIsProcessing(true);
-    try {
-      const openedThisVisit = currentVisitOpenedRef.current;
-      if (phase === "initial") {
-        if (isLast) return;
-        await processCard(currentCardIndex, openedThisVisit);
-        setIndex((current) => Math.min(totalCards - 1, current + 1));
-        setLoopNotice(null);
+    if (!acquireNavLock()) return;
+    const openedThisVisit = currentVisitOpenedRef.current;
+    if (phase === "initial") {
+      if (isLast) return;
+      reportCard(currentCardIndex, openedThisVisit);
+      setIndex((current) => Math.min(totalCards - 1, current + 1));
+      setLoopNotice(null);
+    } else {
+      reportCard(currentCardIndex, openedThisVisit);
+      const currentId = reviewQueue[reviewCursor];
+      let updatedQueue = reviewQueue;
+      if (openedThisVisit && currentId) {
+        updatedQueue = [
+          ...reviewQueue.filter(
+            (id, idx) => idx !== reviewCursor && id !== currentId,
+          ),
+          currentId,
+        ];
       } else {
-        await processCard(currentCardIndex, openedThisVisit);
-        const currentId = reviewQueue[reviewCursor];
-        let updatedQueue = reviewQueue;
-        if (openedThisVisit && currentId) {
-          updatedQueue = [
-            ...reviewQueue.filter(
-              (id, idx) => idx !== reviewCursor && id !== currentId,
-            ),
-            currentId,
-          ];
-        } else {
-          updatedQueue = reviewQueue.filter((_, idx) => idx !== reviewCursor);
-        }
-        if (updatedQueue.length === 0) {
-          await completeDailyTaskAction(date);
-          setCompleted(true);
-          setReviewing(false);
-          setConfettiActive(true);
-          setLoopNotice(null);
-          setTimeout(() => setConfettiActive(false), 2200);
-          return;
-        }
-        const nextCursor = Math.min(reviewCursor, updatedQueue.length - 1);
-        setReviewQueue(updatedQueue);
-        setReviewCursor(nextCursor);
+        updatedQueue = reviewQueue.filter((_, idx) => idx !== reviewCursor);
       }
-    } finally {
-      currentVisitOpenedRef.current = false;
-      setIsProcessing(false);
-    }
-  };
-
-  const handleComplete = async () => {
-    if (!card || isProcessing) return;
-    setIsProcessing(true);
-    try {
-      const openedThisVisit = currentVisitOpenedRef.current;
-      if (phase === "initial") {
-        await processCard(currentCardIndex, openedThisVisit);
-        if (pendingReviewRef.current.size > 0) {
-          const reviewList = cards
-            .map((entry) => entry.id)
-            .filter((cardId) => pendingReviewRef.current.has(cardId));
-          pendingReviewRef.current.clear();
-          setPendingVersion((value) => value + 1);
-          setLoopCount((count) => count + 1);
-          setPhase("review");
-          setReviewQueue(reviewList);
-          setReviewCursor(0);
-          setLoopNotice("还有没掌握的词，再来一轮");
-          return;
-        }
-        await completeDailyTaskAction(date);
+      if (updatedQueue.length === 0) {
+        void completeDailyTaskAction(date).catch(() => undefined);
         setCompleted(true);
         setReviewing(false);
         setConfettiActive(true);
         setLoopNotice(null);
         setTimeout(() => setConfettiActive(false), 2200);
+        currentVisitOpenedRef.current = false;
+        return;
       }
-    } finally {
-      currentVisitOpenedRef.current = false;
-      setIsProcessing(false);
+      const nextCursor = Math.min(reviewCursor, updatedQueue.length - 1);
+      setReviewQueue(updatedQueue);
+      setReviewCursor(nextCursor);
     }
+    currentVisitOpenedRef.current = false;
+  };
+
+  const handleComplete = async () => {
+    if (!card || isProcessing) return;
+    if (!acquireNavLock()) return;
+    const openedThisVisit = currentVisitOpenedRef.current;
+    if (phase === "initial") {
+      reportCard(currentCardIndex, openedThisVisit);
+      if (pendingReviewRef.current.size > 0) {
+        const reviewList = cards
+          .map((entry) => entry.id)
+          .filter((cardId) => pendingReviewRef.current.has(cardId));
+        pendingReviewRef.current.clear();
+        setPendingVersion((value) => value + 1);
+        setLoopCount((count) => count + 1);
+        setPhase("review");
+        setReviewQueue(reviewList);
+        setReviewCursor(0);
+        setLoopNotice("还有没掌握的词，再来一轮");
+        currentVisitOpenedRef.current = false;
+        return;
+      }
+      void completeDailyTaskAction(date).catch(() => undefined);
+      setCompleted(true);
+      setReviewing(false);
+      setConfettiActive(true);
+      setLoopNotice(null);
+      setTimeout(() => setConfettiActive(false), 2200);
+    }
+    currentVisitOpenedRef.current = false;
   };
 
   const handleStartReview = () => {

--- a/src/app/words/daily/daily-task-page-client.tsx
+++ b/src/app/words/daily/daily-task-page-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Loader } from "lucide-react";
 import { DailyTaskClient } from "@/app/words/daily/daily-task-client";
 import { loadDailyTaskAction } from "@/app/words/daily/actions";
 
@@ -76,8 +77,10 @@ export const DailyTaskPageClient = () => {
           <div className="daily-progress-bar" style={{ width: "0%" }} />
         </div>
         <div className="daily-date">{localDate}</div>
-        <div className="daily-shell">
-          <div className="daily-sentence">任务加载中...</div>
+        <div className="daily-shell daily-shell--loading">
+          <div className="daily-loading" role="status" aria-label="任务加载中">
+            <Loader className="daily-loading-icon" />
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- replace daily loading text with centered lucide spinner
- add daily loading styles and spin keyframes
- decouple card navigation from reporting to remove UI delay

## Testing
- pnpm run lint
- pnpm run typecheck