### PR TITLE
feat(daily): improve loading, optimistic nav, and retry queue

### DIFF
--- a/src/app/words/daily/daily-task-client.tsx
+++ b/src/app/words/daily/daily-task-client.tsx
@@ -7,6 +7,11 @@ import {
   getDailyWordBundleAction,
   recordMemoryEventAction,
 } from "@/app/words/daily/actions";
+import {
+  enqueuePendingMemoryEvent,
+  flushPendingMemoryEvents,
+  type DailyMemoryEventPayload,
+} from "@/lib/memory/pending-events";
 
 type DailyTaskCard = {
   id: string;
@@ -161,6 +166,10 @@ export const DailyTaskClient = ({
   }, []);
 
   useEffect(() => {
+    flushPendingEvents();
+  }, []);
+
+  useEffect(() => {
     const prefix = "daily-task-state:";
     for (let i = 0; i < localStorage.length; i += 1) {
       const key = localStorage.key(i);
@@ -258,13 +267,25 @@ export const DailyTaskClient = ({
     currentVisitOpenedRef.current = true;
   };
 
+  const reportMemoryEvent = async (payload: DailyMemoryEventPayload) => {
+    try {
+      await recordMemoryEventAction(payload);
+    } catch {
+      enqueuePendingMemoryEvent(payload);
+    }
+  };
+
+  const flushPendingEvents = () => {
+    void flushPendingMemoryEvents(recordMemoryEventAction);
+  };
+
   const processCard = async (cardIndex: number, openedThisVisit: boolean) => {
     const target = cards[cardIndex];
     if (!target) return;
 
     await Promise.all(
       target.word_ids.map((wordId) =>
-        recordMemoryEventAction({
+        reportMemoryEvent({
           wordId,
           eventType: "exposure",
           meta: { source: "daily_task", date },
@@ -280,7 +301,7 @@ export const DailyTaskClient = ({
       }
       await Promise.all(
         target.word_ids.map((wordId) =>
-          recordMemoryEventAction({
+          reportMemoryEvent({
             wordId,
             eventType: "mark_known",
             meta: { source: "daily_task", date },
@@ -291,6 +312,7 @@ export const DailyTaskClient = ({
   };
 
   const reportCard = (cardIndex: number, openedThisVisit: boolean) => {
+    flushPendingEvents();
     void processCard(cardIndex, openedThisVisit).catch(() => undefined);
   };
 
@@ -391,6 +413,7 @@ export const DailyTaskClient = ({
 
   const handleOpenSheet = async (wordId: string, wordText: string) => {
     if (isProcessing) return;
+    flushPendingEvents();
     markWordOpened(currentCardIndex);
     setSheetOpen(true);
     setSheetWordId(wordId);
@@ -401,7 +424,7 @@ export const DailyTaskClient = ({
     setSheetBriefLoading(true);
     setSheetDetailLoading(true);
 
-    await recordMemoryEventAction({
+    await reportMemoryEvent({
       wordId,
       eventType: "open_card",
       meta: { source: "daily_task", date },

--- a/src/lib/memory/pending-events.ts
+++ b/src/lib/memory/pending-events.ts
@@ -1,0 +1,112 @@
+"use client";
+
+export type DailyMemoryEventType = "exposure" | "open_card" | "mark_known";
+
+export type DailyMemoryEventPayload = {
+  wordId: string;
+  eventType: DailyMemoryEventType;
+  deltaScore?: number | null;
+  meta?: Record<string, unknown> | null;
+};
+
+type PendingMemoryEvent = DailyMemoryEventPayload & {
+  id: string;
+  signature: string;
+  ts: number;
+  attempts: number;
+  nextAt?: number | null;
+};
+
+const STORAGE_KEY = "daily-memory-event-queue:v1";
+const MAX_QUEUE_SIZE = 200;
+
+const buildSignature = (payload: DailyMemoryEventPayload) => {
+  const meta = payload.meta ?? {};
+  const source = typeof meta.source === "string" ? meta.source : "";
+  const date = typeof meta.date === "string" ? meta.date : "";
+  const delta = payload.deltaScore ?? "";
+  return `${payload.wordId}|${payload.eventType}|${source}|${date}|${delta}`;
+};
+
+const canUseStorage = () =>
+  typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+
+const readQueue = (): PendingMemoryEvent[] => {
+  if (!canUseStorage()) return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as PendingMemoryEvent[];
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((entry) => entry && typeof entry.id === "string");
+  } catch {
+    return [];
+  }
+};
+
+const writeQueue = (queue: PendingMemoryEvent[]) => {
+  if (!canUseStorage()) return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(queue));
+  } catch {
+    // Ignore storage quota errors.
+  }
+};
+
+const backoffMs = (attempts: number) => {
+  const base = 1500;
+  const max = 60_000;
+  return Math.min(max, base * 2 ** Math.min(attempts, 6));
+};
+
+export const enqueuePendingMemoryEvent = (payload: DailyMemoryEventPayload) => {
+  if (!canUseStorage()) return;
+  const signature = buildSignature(payload);
+  const queue = readQueue();
+  const existingIndex = queue.findIndex((entry) => entry.signature === signature);
+  const entry: PendingMemoryEvent = {
+    ...payload,
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    signature,
+    ts: Date.now(),
+    attempts: 0,
+    nextAt: null,
+  };
+  if (existingIndex >= 0) {
+    queue[existingIndex] = {
+      ...queue[existingIndex],
+      ...entry,
+    };
+  } else {
+    queue.push(entry);
+  }
+  const trimmed = queue.slice(-MAX_QUEUE_SIZE);
+  writeQueue(trimmed);
+};
+
+export const flushPendingMemoryEvents = async (
+  send: (payload: DailyMemoryEventPayload) => Promise<unknown>,
+) => {
+  if (!canUseStorage()) return;
+  const queue = readQueue();
+  if (queue.length === 0) return;
+  const now = Date.now();
+  const remaining: PendingMemoryEvent[] = [];
+  for (const entry of queue) {
+    if (entry.nextAt && entry.nextAt > now) {
+      remaining.push(entry);
+      continue;
+    }
+    try {
+      await send(entry);
+    } catch {
+      const attempts = entry.attempts + 1;
+      remaining.push({
+        ...entry,
+        attempts,
+        nextAt: Date.now() + backoffMs(attempts),
+      });
+    }
+  }
+  writeQueue(remaining);
+};


### PR DESCRIPTION
## Summary
- replace daily loading text with centered lucide spinner
- add daily loading styles and spin keyframes
- decouple card navigation from reporting to remove UI delay
- persist failed memory events in localStorage with retry/backoff

## Testing
- pnpm run lint
- pnpm run typecheck