### PR TITLE
feat(memory): set daily target default to 35

### DIFF
--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -73,6 +73,9 @@ This document reflects the current public schema in Supabase for the MVP single-
   - last_exposed_at (timestamptz, nullable)
   - last_interaction_at (timestamptz, nullable)
   - stability (numeric, default 0)
+  - daily_open_count (int, default 0)
+  - daily_difficulty (numeric, default 0)
+  - daily_window_at (timestamptz, nullable)
   - created_at (timestamptz, default now())
   - updated_at (timestamptz, default now())
 - Notes:
@@ -118,11 +121,12 @@ This document reflects the current public schema in Supabase for the MVP single-
 - Purpose: Global memory algorithm parameters (single row).
 - Columns:
   - id (uuid, PK, default gen_random_uuid())
-  - daily_target (int, default 20)
+  - daily_target (int, default 35)
   - weight_forget (numeric, default 1)
   - weight_novelty (numeric, default 1)
   - weight_backlog (numeric, default 1)
   - weight_score (numeric, default 1)
+  - weight_difficulty (numeric, default 0.6)
   - half_life_base (numeric, default 3)
   - half_life_growth (numeric, default 0.3)
   - created_at (timestamptz, default now())

--- a/docs/db-schema.zh.md
+++ b/docs/db-schema.zh.md
@@ -73,6 +73,9 @@
   - last_exposed_at (timestamptz, nullable)：最近曝光时间。
   - last_interaction_at (timestamptz, nullable)：最近交互时间。
   - stability (numeric, default 0)：稳定度（衰减用）。
+  - daily_open_count (int, default 0)：当日打开次数。
+  - daily_difficulty (numeric, default 0)：当日困难度。
+  - daily_window_at (timestamptz, nullable)：当日窗口起点。
   - created_at (timestamptz)
   - updated_at (timestamptz)
 - 说明：updated_at 由触发器自动更新。
@@ -117,11 +120,12 @@
 - 作用：全局推荐参数（单行）。
 - 字段：
   - id (uuid, PK)
-  - daily_target (int, default 20)：每日目标词数。
+  - daily_target (int, default 35)：每日目标词数。
   - weight_forget (numeric, default 1)：遗忘风险权重。
   - weight_novelty (numeric, default 1)：新词权重。
   - weight_backlog (numeric, default 1)：曝光不足惩罚权重。
   - weight_score (numeric, default 1)：记忆分数权重。
+  - weight_difficulty (numeric, default 0.6)：当日困难度权重。
   - half_life_base (numeric, default 3)：基础半衰期（天）。
   - half_life_growth (numeric, default 0.3)：随稳定度增长的半衰期系数。
   - created_at (timestamptz)

--- a/package.json
+++ b/package.json
@@ -46,5 +46,6 @@
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
-  }
+  },
+  "packageManager": "pnpm@8.6.9+sha512.2cf11a086be557875519e25e1ea8bfa4247f4844e8a2a99272fdb072bd204ea19479ba64b75c3d4c8117d1ac0b3212cedbda7ba5c5dfcf964ee7d07bd139dcd3"
 }

--- a/src/lib/memory/index.ts
+++ b/src/lib/memory/index.ts
@@ -27,6 +27,7 @@ export type MemorySettings = {
   weight_novelty: number | string;
   weight_backlog: number | string;
   weight_score: number | string;
+  weight_difficulty: number | string;
   half_life_base: number | string;
   half_life_growth: number | string;
 };
@@ -42,11 +43,12 @@ export const getMemorySettings = async () => {
   const row = (data ?? [])[0] as MemorySettings | undefined;
   if (!row) {
     return {
-      daily_target: 20,
+      daily_target: 35,
       weight_forget: 1,
       weight_novelty: 1,
       weight_backlog: 1,
       weight_score: 1,
+      weight_difficulty: 0.6,
       half_life_base: 3,
       half_life_growth: 0.3,
     } as MemorySettings;


### PR DESCRIPTION
## Summary
- set daily target default to 35 in settings and fallback
- update memory settings defaults in Supabase
- refresh schema docs and memory settings type

## Testing
- pnpm run lint
- pnpm run typecheck