### PR TITLE
feat(daily): show multiple context lines

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -139,6 +139,61 @@ body {
   font-family: inherit;
 }
 
+.word-sheet-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.word-sheet-section-title {
+  font-size: 0.7rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.word-sheet-section-body {
+  font-size: 0.95rem;
+  color: var(--foreground);
+}
+
+.word-sheet-section-body p {
+  margin: 0 0 12px;
+}
+
+.word-sheet-section-body p:last-child {
+  margin-bottom: 0;
+}
+
+.word-sheet-context-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.word-sheet-context-item {
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.85rem;
+  border: 1px dashed var(--border-subtle);
+  background: color-mix(in srgb, var(--background) 92%, var(--foreground) 8%);
+}
+
+.word-sheet-context-line {
+  font-size: 0.95rem;
+  color: var(--foreground);
+}
+
+.word-sheet-context-translation {
+  margin-top: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.word-sheet-context-translation--loading {
+  opacity: 0.7;
+}
+
+
 .sheet-backdrop {
   background: color-mix(in srgb, var(--foreground) 28%, transparent);
   opacity: 0;

--- a/src/app/words/[slug]/components/word-card-sheet.tsx
+++ b/src/app/words/[slug]/components/word-card-sheet.tsx
@@ -15,6 +15,7 @@ interface WordCardSheetProps {
   wordText: string;
   phon?: string;
   contextLine?: string;
+  contextLines?: Array<{ line: string; translation?: string }>;
   contextLoading?: boolean;
   activeMode: WordCardMode;
   onModeChange: (mode: WordCardMode) => void;
@@ -45,6 +46,7 @@ export const WordCardSheet = ({
   wordText,
   phon,
   contextLine,
+  contextLines,
   contextLoading = false,
   activeMode,
   onModeChange,
@@ -58,6 +60,14 @@ export const WordCardSheet = ({
   const audioRef = useRef<HTMLAudioElement>(null);
   const resolvedAudioSrc = audio?.src;
   const canPlayAudio = Boolean(resolvedAudioSrc);
+  const resolvedContextLines =
+    contextLines && contextLines.length > 0
+      ? contextLines
+      : contextLine
+        ? [{ line: contextLine }]
+        : [];
+  const contextListLoading =
+    contextLoading && resolvedContextLines.length === 0;
 
   const handlePlay = () => {
     if (!canPlayAudio) return;
@@ -109,15 +119,6 @@ export const WordCardSheet = ({
               dangerouslySetInnerHTML={{ __html: phon }}
             />
           )}
-          {(contextLoading || contextLine) && (
-            <div className="markdown-body border-b border-dashed border-[color:var(--border-subtle)] pb-3 text-sm text-[color:var(--text-muted)]">
-              {contextLoading ? (
-                <span>上下文解析中…</span>
-              ) : (
-                <Markdown>{`> ${contextLine}`}</Markdown>
-              )}
-            </div>
-          )}
           <div className="inline-flex items-center gap-1 rounded-full border border-[color:var(--border-subtle)] p-1 text-[color:var(--text-muted)]">
             <button
               type="button"
@@ -159,14 +160,52 @@ export const WordCardSheet = ({
         ) : null
       }
     >
-      <div className="min-h-[160px] text-[color:var(--foreground)]">
-        {activeContent.loading ? (
-          <span className="text-sm text-[color:var(--text-muted)]">
-            生成中…
-          </span>
-        ) : (
-          <Markdown>{activeContent.content || ""}</Markdown>
-        )}
+      <div className="min-h-[160px] space-y-6 text-[color:var(--foreground)]">
+        <section className="word-sheet-section">
+          <div className="word-sheet-section-title">词义</div>
+          <div className="word-sheet-section-body">
+            {activeContent.loading ? (
+              <span className="text-sm text-[color:var(--text-muted)]">
+                生成中…
+              </span>
+            ) : (
+              <Markdown>{activeContent.content || ""}</Markdown>
+            )}
+          </div>
+        </section>
+        <section className="word-sheet-section">
+          <div className="word-sheet-section-title">
+            语境记录
+            {resolvedContextLines.length > 0
+              ? ` (${resolvedContextLines.length})`
+              : ""}
+          </div>
+          {resolvedContextLines.length === 0 ? (
+            <div className="text-sm text-[color:var(--text-muted)]">
+              {contextListLoading ? "语境解析中…" : "暂无语境记录"}
+            </div>
+          ) : (
+            <div className="word-sheet-context-list">
+              {resolvedContextLines.map((item, index) => (
+                <div
+                  key={`${item.line}-${index}`}
+                  className="word-sheet-context-item"
+                >
+                  <div className="word-sheet-context-line">{item.line}</div>
+                  {item.translation ? (
+                    <div className="word-sheet-context-translation">
+                      {item.translation}
+                    </div>
+                  ) : contextLoading ? (
+                    <div className="word-sheet-context-translation word-sheet-context-translation--loading">
+                      翻译中…
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
       </div>
       {canPlayAudio && <audio ref={audioRef} src={resolvedAudioSrc} />}
     </MobileSheet>

--- a/src/app/words/daily/actions.ts
+++ b/src/app/words/daily/actions.ts
@@ -2,13 +2,13 @@
 
 import { applyMemoryEvent } from "@/lib/memory";
 import { completeDailyTask, type DailyTaskResult, generateDailyTask } from "@/lib/memory/task";
-import { getWordCardBundle } from "@/lib/words/ai-service";
+import { getWordCardBundle, translateSentence } from "@/lib/words/ai-service";
 import { getSupabaseClient } from "@/lib/supabase";
 
 type WordContext = {
   id: string;
   text: string;
-  contextLine: string;
+  contextLines: string[];
 };
 
 type DailyMemoryEventType = "exposure" | "open_card" | "mark_known";
@@ -41,6 +41,17 @@ export const getDailyWordBundleAction = async (payload: {
     force: payload.force,
     maxChars: payload.maxChars,
   });
+};
+
+export const translateContextLinesAction = async (payload: {
+  lines: string[];
+}) => {
+  const lines = (payload.lines ?? []).map((line) => line.trim()).filter(Boolean);
+  if (lines.length === 0) return [];
+  const translations = await Promise.all(
+    lines.map((line) => translateSentence(line)),
+  );
+  return translations;
 };
 
 const loadDailyTask = async (date: string): Promise<DailyTaskResult> => {
@@ -127,9 +138,9 @@ const loadWordContexts = async (
   }
 
   const result = new Map<string, WordContext>();
+  const seenByWord = new Map<string, Set<string>>();
   for (const entry of entries ?? []) {
     const wordId = entry.word_id as string;
-    if (result.has(wordId)) continue;
     const wordRow = entry.words as { text?: string } | null;
     const text = wordRow?.text || fallbackMap.get(wordId) || "";
     const contextLine =
@@ -137,11 +148,24 @@ const loadWordContexts = async (
       (entry.source_text as string | null) ||
       (entry.context as string | null) ||
       "";
-    result.set(wordId, {
-      id: wordId,
-      text,
-      contextLine: contextLine.trim(),
-    });
+    const normalized = contextLine.trim();
+    if (!normalized) continue;
+    if (!result.has(wordId)) {
+      result.set(wordId, {
+        id: wordId,
+        text,
+        contextLines: [],
+      });
+      seenByWord.set(wordId, new Set());
+    } else if (!result.get(wordId)?.text && text) {
+      result.get(wordId)!.text = text;
+    }
+    const seen = seenByWord.get(wordId) ?? new Set<string>();
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      seenByWord.set(wordId, seen);
+      result.get(wordId)?.contextLines.push(normalized);
+    }
   }
 
   for (const wordId of wordIds) {
@@ -149,7 +173,7 @@ const loadWordContexts = async (
       result.set(wordId, {
         id: wordId,
         text: fallbackMap.get(wordId) || "",
-        contextLine: "",
+        contextLines: [],
       });
     }
   }

--- a/src/app/words/daily/daily-task-client.tsx
+++ b/src/app/words/daily/daily-task-client.tsx
@@ -6,6 +6,7 @@ import {
   completeDailyTaskAction,
   getDailyWordBundleAction,
   recordMemoryEventAction,
+  translateContextLinesAction,
 } from "@/app/words/daily/actions";
 import {
   enqueuePendingMemoryEvent,
@@ -25,7 +26,7 @@ type DailyTaskCard = {
 type WordContext = {
   id: string;
   text: string;
-  contextLine: string;
+  contextLines: string[];
 };
 
 interface DailyTaskClientProps {
@@ -108,13 +109,20 @@ export const DailyTaskClient = ({
   const [sheetOpen, setSheetOpen] = useState(false);
   const [sheetWordId, setSheetWordId] = useState<string | null>(null);
   const [sheetWordText, setSheetWordText] = useState("");
-  const [sheetContextLine, setSheetContextLine] = useState("");
+  const [sheetContextLines, setSheetContextLines] = useState<string[]>([]);
+  const [sheetContextTranslations, setSheetContextTranslations] = useState<
+    string[]
+  >([]);
+  const [sheetContextLoading, setSheetContextLoading] = useState(false);
   const [sheetMode, setSheetMode] = useState<"brief" | "detail">("brief");
   const [sheetBrief, setSheetBrief] = useState("");
   const [sheetDetail, setSheetDetail] = useState("");
   const [sheetBriefLoading, setSheetBriefLoading] = useState(false);
   const [sheetDetailLoading, setSheetDetailLoading] = useState(false);
   const bundleCacheRef = useRef<BundleCache>({});
+  const contextCacheRef = useRef<
+    Record<string, { linesKey: string; translations: string[] }>
+  >({});
   const pendingReviewRef = useRef<Set<string>>(new Set());
   const masteredCardsRef = useRef<Set<string>>(new Set());
   const currentVisitOpenedRef = useRef(false);
@@ -418,8 +426,12 @@ export const DailyTaskClient = ({
     setSheetOpen(true);
     setSheetWordId(wordId);
     setSheetWordText(wordText);
-    const contextLine = wordContexts[wordId]?.contextLine?.trim() || wordText;
-    setSheetContextLine(contextLine);
+    const contextLines =
+      wordContexts[wordId]?.contextLines?.map((line) => line.trim()) ?? [];
+    const cleanedContextLines = contextLines.filter(Boolean);
+    setSheetContextLines(cleanedContextLines);
+    setSheetContextTranslations([]);
+    setSheetContextLoading(cleanedContextLines.length > 0);
     setSheetMode("brief");
     setSheetBriefLoading(true);
     setSheetDetailLoading(true);
@@ -436,13 +448,41 @@ export const DailyTaskClient = ({
       setSheetDetail(cached.detail);
       setSheetBriefLoading(false);
       setSheetDetailLoading(false);
-      return;
     }
+
+    const primaryContextLine =
+      cleanedContextLines[0]?.trim() || wordText;
+
+    const contextCache = contextCacheRef.current[wordId];
+    const linesKey = cleanedContextLines.join("\n");
+    if (contextCache && contextCache.linesKey === linesKey) {
+      setSheetContextTranslations(contextCache.translations);
+      setSheetContextLoading(false);
+    } else if (cleanedContextLines.length > 0) {
+      try {
+        const translations = await translateContextLinesAction({
+          lines: cleanedContextLines,
+        });
+        contextCacheRef.current[wordId] = {
+          linesKey,
+          translations,
+        };
+        setSheetContextTranslations(translations);
+      } catch {
+        setSheetContextTranslations([]);
+      } finally {
+        setSheetContextLoading(false);
+      }
+    } else {
+      setSheetContextLoading(false);
+    }
+
+    if (cached) return;
 
     try {
       const bundle = await getDailyWordBundleAction({
         word: wordText,
-        sourceText: contextLine,
+        sourceText: primaryContextLine,
       });
       bundleCacheRef.current[wordId] = {
         brief: bundle.brief ?? "",
@@ -606,8 +646,11 @@ export const DailyTaskClient = ({
         open={sheetOpen}
         onClose={handleCloseSheet}
         wordText={sheetWordText}
-        contextLine={sheetContextLine}
-        contextLoading={sheetBriefLoading || sheetDetailLoading}
+        contextLines={sheetContextLines.map((line, index) => ({
+          line,
+          translation: sheetContextTranslations[index],
+        }))}
+        contextLoading={sheetContextLoading}
         activeMode={sheetMode}
         onModeChange={setSheetMode}
         brief={{

--- a/src/app/words/daily/daily-task-page-client.tsx
+++ b/src/app/words/daily/daily-task-page-client.tsx
@@ -17,7 +17,7 @@ type DailyTaskCard = {
 type WordContext = {
   id: string;
   text: string;
-  contextLine: string;
+  contextLines: string[];
 };
 
 type LoadResult = {


### PR DESCRIPTION
## Summary
- return multiple context lines per word for daily tasks
- render context lines + translations in word card sheet
- separate word meaning vs context blocks and add paragraph spacing

## Testing
- pnpm run lint
- pnpm run typecheck