### PR TITLE
feat: hide context record in daily word cards

### DIFF
--- a/src/app/words/daily/actions.ts
+++ b/src/app/words/daily/actions.ts
@@ -40,6 +40,7 @@ export const getDailyWordBundleAction = async (payload: {
   return getWordCardBundle(payload.word, payload.sourceText, {
     force: payload.force,
     maxChars: payload.maxChars,
+    contextMode: "none",
   });
 };
 

--- a/src/lib/words/ai-service.ts
+++ b/src/lib/words/ai-service.ts
@@ -246,6 +246,7 @@ export const getWordCardBundle = async (
     maxChars?: number;
     contextLines?: string[];
     contextTranslations?: string[];
+    contextMode?: "auto" | "none";
   },
 ) => {
   const maxChars = Math.max(80, Math.min(options?.maxChars ?? 160, 320));
@@ -253,6 +254,7 @@ export const getWordCardBundle = async (
   const contextTranslations = (options?.contextTranslations ?? []).filter(
     Boolean,
   );
+  const contextMode = options?.contextMode ?? "auto";
   const contextBlock =
     contextLines.length > 0
       ? `\ncontext_lines:\n${contextLines
@@ -265,7 +267,7 @@ export const getWordCardBundle = async (
           .map((line, index) => `${index + 1}) ${line}`)
           .join("\n")}`
       : "\ncontext_translations:\n(none)";
-  const prompt = `word: ${word}\nsource_text: ${sourceText}\nmax_chars: ${maxChars}${contextBlock}${translationBlock}`;
+  const prompt = `word: ${word}\nsource_text: ${sourceText}\nmax_chars: ${maxChars}\ncontext_mode: ${contextMode}${contextBlock}${translationBlock}`;
   const inputHash = createInputHash({
     version: 2,
     type: "word_card_bundle",

--- a/src/lib/words/constants.ts
+++ b/src/lib/words/constants.ts
@@ -87,7 +87,13 @@ export const WORD_CARD_BUNDLE_PROMPT = `
 1) 必须输出 JSON，且只输出 JSON，不要多余解释。
 2) JSON 结构固定：{"context":"...","brief":"...","detail":"..."}
 3) context 必须是英文，来自给定内容中包含该单词的最相关句子或短语，必须包含该单词（大小写可不同），长度不超过 max_chars。
-4) brief 使用 Markdown，格式严格为三段，段与段之间空一行，且每段单独成行：
+4) 如果 context_mode 为 none，brief 使用 Markdown，格式严格为三段，段与段之间空一行，且每段单独成行：
+   释义：...（不超过 20 字，只解释单词在 context 中的意思）
+
+   例句：...（必须与 context 完全一致）
+
+   例句翻译：...（必须是 context 的中文翻译）
+5) 如果 context_mode 不是 none，brief 使用 Markdown，格式严格为四段，段与段之间空一行，且每段单独成行：
    释义：...（不超过 20 字，只解释单词在 context 中的意思）
 
    例句：...（必须与 context 完全一致）
@@ -95,8 +101,7 @@ export const WORD_CARD_BUNDLE_PROMPT = `
    例句翻译：...（必须是 context 的中文翻译）
 
    语境记录：1) 英文 — 中文；2) 英文 — 中文；3) 英文 — 中文（如无语境，写“语境记录：暂无”）
-
-5) detail 使用 Markdown，格式严格为五段，段与段之间空一行，且每段单独成行：
+6) detail 使用 Markdown，格式严格为五段，段与段之间空一行，且每段单独成行：
    释义：...（完整、准确）
 
    例句：...（一句话）
@@ -106,11 +111,12 @@ export const WORD_CARD_BUNDLE_PROMPT = `
    语法要点：1) ...；2) ...（至少两条）
 
    语义补充：1) ...；2) ...（至少两条）
-6) brief 与 detail 必须全部使用中文，不要输出英文解释（除目标单词本身可保留英文形式）。
-7) brief 必须短、只保留核心信息；detail 必须补充语法与语义差异，体现深度。
-8) 除“语法要点/语义补充”中的 1) 2) 与“语境记录”中的 1) 2) 3) 之外，不要使用项目符号或列表。
-9) 如果输入内容包含 [[word]] 标记，输出 context 与例句时去掉 [[ ]]。
-10) 如果提供了 context_lines 与 context_translations，语境记录必须使用它们，且顺序保持一致；不得擅自改写英文语境或中文翻译。
+7) brief 与 detail 必须全部使用中文，不要输出英文解释（除目标单词本身可保留英文形式）。
+8) brief 必须短、只保留核心信息；detail 必须补充语法与语义差异，体现深度。
+9) 除“语法要点/语义补充”中的 1) 2) 与“语境记录”中的 1) 2) 3) 之外，不要使用项目符号或列表。
+10) 如果输入内容包含 [[word]] 标记，输出 context 与例句时去掉 [[ ]]。
+11) 如果提供了 context_lines 与 context_translations，语境记录必须使用它们，且顺序保持一致；不得擅自改写英文语境或中文翻译。
+12) 当 context_mode 为 none 时，严禁在 brief 中出现“语境记录”相关内容。
 `;
 
 export const PASSAGE_TRANSLATE_PROMPT = `


### PR DESCRIPTION
## Summary
- add `context_mode` support to word card bundle prompt/AI service
- disable brief context record for daily word cards
- keep API card behavior unchanged

## Testing
- pnpm run lint
- pnpm run typecheck