### PR TITLE
feat(memory): use user timezone for daily idempotency

### DIFF
--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -169,9 +169,9 @@ This document reflects the current public schema in Supabase for the MVP single-
   - word_id, word_text, memory_score, exposure_count, success_count, fail_count,
     last_exposed_at, stability, priority
 
-### apply_memory_event(p_word_id, p_session_id, p_event_type, p_delta_score, p_payload)
+### apply_memory_event(p_word_id, p_session_id, p_event_type, p_delta_score, p_payload, p_tz)
 - Appends to word_memory_events and updates word_memory_states.
-- Note (2026-01-31): For score-impacting events (open_card/mark_known/mark_unknown), memory_score updates are idempotent per word + event_type per day. The event log is still written, but state changes only apply once per day for the same word/event_type.
+- Note (2026-01-31): For score-impacting events (open_card/mark_known/mark_unknown), memory_score updates are idempotent per word + event_type per day (day boundary uses p_tz, default UTC). The event log is still written, but state changes only apply once per day for the same word/event_type.
 - Note (2026-01-31): If open_card occurs for a word on a given day, subsequent mark_known updates for the same word/day are ignored for scoring (event log still records).
 
 ## Triggers

--- a/docs/db-schema.zh.md
+++ b/docs/db-schema.zh.md
@@ -165,9 +165,9 @@
 ### get_memory_feed(p_limit int)
 - 作用：按推荐分数计算并返回 feed。
 
-### apply_memory_event(p_word_id, p_session_id, p_event_type, p_delta_score, p_payload)
+### apply_memory_event(p_word_id, p_session_id, p_event_type, p_delta_score, p_payload, p_tz)
 - 作用：写入事件 + 更新记忆状态。
-- 备注（2026-01-31）：对会影响分数的事件（open_card/mark_known/mark_unknown），同一 word + event_type 在同一天只会对 memory_score 生效一次。事件日志仍会写入，但状态更新仅当日首次生效。
+- 备注（2026-01-31）：对会影响分数的事件（open_card/mark_known/mark_unknown），同一 word + event_type 在同一天只会对 memory_score 生效一次（“同一天”使用 p_tz 的日界线，默认 UTC）。事件日志仍会写入，但状态更新仅当日首次生效。
 - 备注（2026-01-31）：若同一单词当天发生 open_card，则当天的 mark_known 记分将被忽略（事件仍会记录）。
 
 ### set_updated_at() 触发器

--- a/src/app/api/memory/event/route.ts
+++ b/src/app/api/memory/event/route.ts
@@ -29,6 +29,7 @@ export async function POST(request: NextRequest) {
   const wordId = parsedPayload.data.wordId;
   const sessionId = parsedPayload.data.sessionId ?? null;
   const eventType = parsedPayload.data.eventType;
+  const timezone = parsedPayload.data.timezone ?? null;
 
   try {
     const updated = await applyMemoryEvent({
@@ -37,6 +38,7 @@ export async function POST(request: NextRequest) {
       eventType,
       deltaScore: parsedPayload.data.deltaScore,
       payload: parsedPayload.data.payload,
+      timezone,
     });
 
     if (eventType === "open_card" && sessionId) {

--- a/src/app/api/memory/session/complete/route.ts
+++ b/src/app/api/memory/session/complete/route.ts
@@ -26,6 +26,7 @@ export async function POST(request: NextRequest) {
     parsedPayload.success && parsedPayload.data.sessionId
       ? parsedPayload.data.sessionId
       : "";
+  const timezone = parsedPayload.success ? parsedPayload.data.timezone ?? null : null;
   if (!sessionId || sessionId.length === 0) {
     return NextResponse.json({ error: "sessionId required" }, { status: 400 });
   }
@@ -59,6 +60,7 @@ export async function POST(request: NextRequest) {
           sessionId,
           eventType: "mark_known",
           payload: { source: "session_complete" },
+          timezone,
         }),
       ),
     );

--- a/src/app/api/memory/session/start/route.ts
+++ b/src/app/api/memory/session/start/route.ts
@@ -26,6 +26,7 @@ export async function POST(request: NextRequest) {
   const limit = data.limit;
   const groupSize = data.groupSize;
   const target = groupSize ?? limit;
+  const timezone = data.timezone ?? null;
 
   try {
     const feedItems = await getMemoryFeed(target);
@@ -71,6 +72,7 @@ export async function POST(request: NextRequest) {
           sessionId,
           eventType: "exposure",
           payload: { source: "session_start" },
+          timezone,
         }),
       ),
     );

--- a/src/app/words/daily/actions.ts
+++ b/src/app/words/daily/actions.ts
@@ -19,12 +19,14 @@ export const recordMemoryEventAction = async (payload: {
   eventType: DailyMemoryEventType;
   deltaScore?: number | null;
   meta?: Record<string, unknown> | null;
+  timezone?: string | null;
 }) => {
   return applyMemoryEvent({
     wordId: payload.wordId,
     eventType: payload.eventType,
     deltaScore: payload.deltaScore ?? null,
     payload: payload.meta ?? null,
+    timezone: payload.timezone ?? null,
   });
 };
 

--- a/src/app/words/daily/daily-task-client.tsx
+++ b/src/app/words/daily/daily-task-client.tsx
@@ -137,6 +137,13 @@ export const DailyTaskClient = ({
   const [pendingVersion, setPendingVersion] = useState(0);
   const [masteredVersion, setMasteredVersion] = useState(0);
   const confettiPieces = useMemo(() => buildConfetti(), []);
+  const timezone = useMemo(() => {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+    } catch {
+      return "UTC";
+    }
+  }, []);
 
   const cardIndexById = useMemo(() => {
     return new Map(cards.map((entry, idx) => [entry.id, idx]));
@@ -298,10 +305,14 @@ export const DailyTaskClient = ({
   };
 
   const reportMemoryEvent = async (payload: DailyMemoryEventPayload) => {
+    const resolvedPayload = {
+      ...payload,
+      timezone: payload.timezone ?? timezone,
+    };
     try {
-      await recordMemoryEventAction(payload);
+      await recordMemoryEventAction(resolvedPayload);
     } catch {
-      enqueuePendingMemoryEvent(payload);
+      enqueuePendingMemoryEvent(resolvedPayload);
     }
   };
 

--- a/src/lib/memory/index.ts
+++ b/src/lib/memory/index.ts
@@ -19,6 +19,7 @@ export type MemoryEventPayload = {
   eventType: "exposure" | "open_card" | "mark_known" | "mark_unknown";
   deltaScore?: number | null;
   payload?: Record<string, unknown> | null;
+  timezone?: string | null;
 };
 
 export type MemorySettings = {
@@ -80,6 +81,7 @@ export const applyMemoryEvent = async (payload: MemoryEventPayload) => {
     p_event_type: payload.eventType,
     p_delta_score: payload.deltaScore ?? null,
     p_payload: payload.payload ?? null,
+    p_tz: payload.timezone ?? null,
   });
 
   if (error) {

--- a/src/lib/memory/pending-events.ts
+++ b/src/lib/memory/pending-events.ts
@@ -7,6 +7,7 @@ export type DailyMemoryEventPayload = {
   eventType: DailyMemoryEventType;
   deltaScore?: number | null;
   meta?: Record<string, unknown> | null;
+  timezone?: string | null;
 };
 
 type PendingMemoryEvent = DailyMemoryEventPayload & {

--- a/src/lib/schemas/memory.ts
+++ b/src/lib/schemas/memory.ts
@@ -26,6 +26,7 @@ export const memoryEventRequestSchema = z
     sessionId: optionalNullableTrimmedStringSchema,
     eventType: trimmedEventTypeSchema,
     deltaScore: optionalFiniteNumberSchema,
+    timezone: optionalNullableTrimmedStringSchema,
     payload: z.record(z.unknown()).nullable().optional(),
   })
   .passthrough();
@@ -34,6 +35,7 @@ export const startSessionPayloadSchema = z
   .object({
     limit: optionalPositiveIntSchema,
     groupSize: optionalPositiveIntSchema,
+    timezone: optionalNullableTrimmedStringSchema,
     params: z.record(z.unknown()).nullable().optional(),
   })
   .passthrough();
@@ -41,6 +43,7 @@ export const startSessionPayloadSchema = z
 export const completeSessionPayloadSchema = z
   .object({
     sessionId: optionalNullableTrimmedStringSchema,
+    timezone: optionalNullableTrimmedStringSchema,
   })
   .passthrough();
 


### PR DESCRIPTION
## Summary
- add timezone parameter to apply_memory_event RPC and use local day boundary
- pass timezone through memory event APIs and daily client
- document updated RPC signature

## Testing
- pnpm run lint
- pnpm run typecheck