### PR TITLE
fix(auth): skip pkce exchange for extension callback

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -30,6 +30,10 @@ const CallbackContent = () => {
           { type: "supabase_oauth_code", code },
           "https://www.parkgogogo.me",
         );
+        if (isExtension) {
+          setIsExtensionDone(true);
+          return;
+        }
       }
 
       if (!code && !accessToken) {


### PR DESCRIPTION
## Summary
- skip code exchange on /auth/callback when client=extension to avoid PKCE verifier errors 
## Testing 
- pnpm run lint 
- pnpm run typecheck