### PR TITLE
fix(auth): only post oauth code for extension client

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -51,16 +51,14 @@ const CallbackContent = () => {
       const accessToken = hashParams.get("access_token");
       const refreshToken = hashParams.get("refresh_token");
 
-      if (code && !hasPostedRef.current) {
+      if (isExtension && code && !hasPostedRef.current) {
         hasPostedRef.current = true;
         window.postMessage(
           { type: "supabase_oauth_code", code },
           window.location.origin,
         );
-        if (isExtension) {
-          setIsExtensionDone(true);
-          return;
-        }
+        setIsExtensionDone(true);
+        return;
       }
 
       if (!code && !accessToken) {


### PR DESCRIPTION
## Summary
- gate callback postMessage behind client=extension
- avoid broadcasting supabase_oauth_code during normal site login
- keep extension callback flow unchanged

## Validation
- pnpm run lint
- pnpm run typecheck