### PR TITLE
feat(auth): add rolling session refresh for web and extension

### DIFF
--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import {
+  clearAuthCookies,
+  getRefreshTokenFromRequest,
+  refreshAuthSession,
+  setAuthCookies,
+} from "@/lib/auth";
+
+type RefreshPayload = {
+  client?: "web" | "extension";
+  refreshToken?: string;
+};
+
+export async function POST(request: Request) {
+  const payload = (await request.json().catch(() => null)) as RefreshPayload | null;
+  const client = payload?.client ?? "web";
+  const refreshToken =
+    client === "extension"
+      ? payload?.refreshToken ?? null
+      : getRefreshTokenFromRequest(request);
+
+  if (!refreshToken) {
+    return NextResponse.json({ error: "missing_refresh_token" }, { status: 400 });
+  }
+
+  const refreshed = await refreshAuthSession(refreshToken);
+  if (!refreshed) {
+    const response = NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    if (client !== "extension") {
+      clearAuthCookies(response);
+    }
+    return response;
+  }
+
+  const response = NextResponse.json(refreshed);
+  if (client !== "extension") {
+    setAuthCookies(response, {
+      accessToken: refreshed.accessToken,
+      refreshToken: refreshed.refreshToken,
+      maxAge: refreshed.expiresIn,
+    });
+  }
+  return response;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -71,6 +71,56 @@ export const clearAuthCookies = (response: NextResponse) => {
   });
 };
 
+const decodeJwtExp = (token: string): number | null => {
+  const [, payload = ""] = token.split(".");
+  if (!payload) return null;
+  try {
+    const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+    const raw = atob(padded);
+    const parsed = JSON.parse(raw) as { exp?: number };
+    return typeof parsed.exp === "number" ? parsed.exp : null;
+  } catch {
+    return null;
+  }
+};
+
+export const shouldRefreshAccessToken = (
+  accessToken: string | null | undefined,
+  options?: { thresholdSeconds?: number },
+) => {
+  if (!accessToken) return true;
+  const exp = decodeJwtExp(accessToken);
+  if (!exp) return true;
+  const now = Math.floor(Date.now() / 1000);
+  const threshold = options?.thresholdSeconds ?? 15 * 60;
+  return exp - now <= threshold;
+};
+
+export const refreshAuthSession = async (refreshToken: string) => {
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase.auth.refreshSession({
+    refresh_token: refreshToken,
+  });
+
+  if (
+    error ||
+    !data.session?.access_token ||
+    !data.session?.refresh_token
+  ) {
+    return null;
+  }
+
+  return {
+    accessToken: data.session.access_token,
+    refreshToken: data.session.refresh_token,
+    expiresIn: data.session.expires_in ?? 60 * 60,
+    expiresAt: new Date(
+      Date.now() + (data.session.expires_in ?? 60 * 60) * 1000,
+    ).toISOString(),
+  };
+};
+
 export const getUserFromAccessToken = async (accessToken: string) => {
   const supabase = getSupabaseClient({ accessToken });
   const { data, error } = await supabase.auth.getUser(accessToken);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,14 +1,63 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  ACCESS_TOKEN_COOKIE,
+  REFRESH_TOKEN_COOKIE,
+  refreshAuthSession,
+  shouldRefreshAccessToken,
+} from "@/lib/auth";
 
-export const middleware = (request: NextRequest) => {
+export const middleware = async (request: NextRequest) => {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set("x-pathname", request.nextUrl.pathname);
   requestHeaders.set("x-search", request.nextUrl.search);
-  return NextResponse.next({
+  const response = NextResponse.next({
     request: {
       headers: requestHeaders,
     },
   });
+
+  const accessToken = request.cookies.get(ACCESS_TOKEN_COOKIE)?.value ?? null;
+  const refreshToken = request.cookies.get(REFRESH_TOKEN_COOKIE)?.value ?? null;
+
+  if (!refreshToken || !shouldRefreshAccessToken(accessToken)) {
+    return response;
+  }
+
+  const refreshed = await refreshAuthSession(refreshToken);
+  if (!refreshed) {
+    response.cookies.set(ACCESS_TOKEN_COOKIE, "", {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: 0,
+    });
+    response.cookies.set(REFRESH_TOKEN_COOKIE, "", {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: 0,
+    });
+    return response;
+  }
+
+  response.cookies.set(ACCESS_TOKEN_COOKIE, refreshed.accessToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: refreshed.expiresIn,
+  });
+  response.cookies.set(REFRESH_TOKEN_COOKIE, refreshed.refreshToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 30,
+  });
+
+  return response;
 };
 
 export const config = {


### PR DESCRIPTION
## Summary
- add auth refresh endpoint at /api/auth/refresh for web and extension clients
- add shared auth helpers to refresh and evaluate token expiry
- refresh auth cookies in middleware for /words routes when token is near expiry

## Validation
- pnpm run lint
- pnpm run typecheck