### PR TITLE
fix(words-daily): initialize completion from server status

### DIFF
--- a/src/app/words/daily/actions.ts
+++ b/src/app/words/daily/actions.ts
@@ -225,6 +225,11 @@ export const loadDailyTaskAction = async (date: string) => {
 
   return {
     date,
+    task: {
+      id: result.task.id,
+      status: result.task.status,
+      completedAt: result.task.completed_at,
+    },
     cards: result.cards.map((card) => ({
       ...card,
       speechToken: createSpeechToken({

--- a/src/app/words/daily/daily-task-client.tsx
+++ b/src/app/words/daily/daily-task-client.tsx
@@ -34,6 +34,7 @@ type WordContext = {
 
 interface DailyTaskClientProps {
   date: string;
+  initialCompleted: boolean;
   cards: DailyTaskCard[];
   wordContexts: Record<string, WordContext>;
 }
@@ -95,6 +96,7 @@ const buildConfetti = () =>
 
 export const DailyTaskClient = ({
   date,
+  initialCompleted,
   cards,
   wordContexts,
 }: DailyTaskClientProps) => {
@@ -104,7 +106,7 @@ export const DailyTaskClient = ({
   const [reviewQueue, setReviewQueue] = useState<string[]>([]);
   const [reviewCursor, setReviewCursor] = useState(0);
   const [isProcessing, setIsProcessing] = useState(false);
-  const [completed, setCompleted] = useState(false);
+  const [completed, setCompleted] = useState(initialCompleted);
   const [reviewing, setReviewing] = useState(false);
   const [confettiActive, setConfettiActive] = useState(false);
   const [loopCount, setLoopCount] = useState(0);
@@ -229,7 +231,6 @@ export const DailyTaskClient = ({
         pendingReview?: string[];
         masteredCards?: string[];
         loopCount?: number;
-        completed?: boolean;
       };
       const validCardIds = new Set(cards.map((entry) => entry.id));
       const storedIndex = typeof parsed.index === "number" ? parsed.index : 0;
@@ -259,9 +260,6 @@ export const DailyTaskClient = ({
       setMasteredVersion((value) => value + 1);
       if (typeof parsed.loopCount === "number") {
         setLoopCount(Math.max(0, parsed.loopCount));
-      }
-      if (parsed.completed) {
-        setCompleted(true);
       }
     } catch {
       // Ignore corrupted storage.

--- a/src/app/words/daily/daily-task-page-client.tsx
+++ b/src/app/words/daily/daily-task-page-client.tsx
@@ -23,6 +23,11 @@ type WordContext = {
 
 type LoadResult = {
   date: string;
+  task: {
+    id: string;
+    status: string;
+    completedAt: string | null;
+  };
   cards: DailyTaskCard[];
   wordContexts: Record<string, WordContext>;
 };
@@ -90,6 +95,7 @@ export const DailyTaskPageClient = () => {
   return (
     <DailyTaskClient
       date={result.date}
+      initialCompleted={result.task.status === "completed"}
       cards={result.cards}
       wordContexts={result.wordContexts}
     />


### PR DESCRIPTION
## Summary\n- return daily task status from server load action\n- initialize daily page completed state from backend status on refresh\n- keep in-session progress optimistic via localStorage state\n\n## Validation\n- pnpm run lint\n- pnpm run typecheck