### PR TITLE
feat(memory): generate daily cards in one AI pass

### DIFF
--- a/src/lib/ai-cache.ts
+++ b/src/lib/ai-cache.ts
@@ -16,7 +16,8 @@ export type AIGenerationType =
   | "passage_translation"
   | "sentence_translation"
   | "memory_sentence"
-  | "memory_grouping";
+  | "memory_grouping"
+  | "memory_cards";
 
 const recordSchema = z.record(z.unknown());
 

--- a/src/lib/memory/ai-service.ts
+++ b/src/lib/memory/ai-service.ts
@@ -4,134 +4,24 @@ import {
   getCachedGeneration,
   saveGeneration,
 } from "@/lib/ai-cache";
-import {
-  MEMORY_GROUP_PROMPT,
-  MEMORY_SENTENCE_PROMPT,
-} from "@/lib/memory/constants";
+import { MEMORY_CARDS_PROMPT } from "@/lib/memory/constants";
 
-const normalizeSentence = (value: string) =>
-  value.replace(/\s+/g, " ").trim();
+type RawContextRecord = {
+  context_line: string;
+  source_text: string;
+  context: string;
+  created_at: string;
+};
+
+type MemoryCardDraft = {
+  words: string[];
+  sentence: string;
+};
+
+const normalizeText = (value: string) => value.replace(/\s+/g, " ").trim();
 
 const normalizeWordToken = (value: string) =>
   value.toLowerCase().replace(/[^a-z0-9-]/g, "").trim();
-
-const escapeRegex = (value: string) =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-const countWordOccurrences = (sentence: string, word: string) => {
-  const normalizedSentence = sentence.toLowerCase();
-  const target = normalizeWordToken(word);
-  if (!target) return 0;
-  const pattern = new RegExp(`\\b${escapeRegex(target)}\\b`, "g");
-  return normalizedSentence.match(pattern)?.length ?? 0;
-};
-
-const includesAllWords = (sentence: string, words: string[]) => {
-  const lower = sentence.toLowerCase();
-  return words.every((word) => lower.includes(word.toLowerCase()));
-};
-
-export const generateMemorySentence = async (options: {
-  words: string[];
-  maxChars: number;
-  maxSentences: number;
-  taskDate: string;
-  contexts: Record<string, string>;
-  force?: boolean;
-}) => {
-  const contextLines = options.words
-    .map((word) => `- ${word}: ${options.contexts[word] || ""}`)
-    .join("\n");
-  const prompt = `words: ${options.words.join(", ")}\nmax_chars: ${options.maxChars}\nmax_sentences: ${options.maxSentences}\ncontexts:\n${contextLines}`;
-  const inputHash = createInputHash({
-    version: 1,
-    type: "memory_sentence",
-    system: MEMORY_SENTENCE_PROMPT,
-    prompt,
-    model: AI_TEXT_MODEL,
-    taskDate: options.taskDate,
-  });
-  const key = `MEMORY_SENT_${options.taskDate}_${inputHash.slice(0, 12)}`;
-
-  if (!options.force) {
-    const cached = await getCachedGeneration("memory_sentence", inputHash);
-    if (cached) return normalizeSentence(cached);
-  }
-
-  const result = await ai_generateText({
-    system: MEMORY_SENTENCE_PROMPT,
-    prompt,
-  });
-  const normalized = normalizeSentence(result);
-  await saveGeneration({
-    type: "memory_sentence",
-    key,
-    inputHash,
-    content: normalized,
-    meta: {
-      words: options.words,
-      contexts: options.contexts,
-      model: AI_TEXT_MODEL,
-      taskDate: options.taskDate,
-    },
-  });
-
-  return normalized;
-};
-
-export const buildFallbackSentence = (words: string[]) => {
-  if (words.length === 1) {
-    return `Today I learned the word ${words[0]}.`;
-  }
-  if (words.length === 2) {
-    return `Today I learned ${words[0]} and ${words[1]}.`;
-  }
-  const tail = words[words.length - 1];
-  const head = words.slice(0, -1).join(", ");
-  return `Today I learned ${head}, and ${tail}.`;
-};
-
-export const ensureMemorySentence = async (options: {
-  words: string[];
-  maxChars: number;
-  maxSentences: number;
-  taskDate: string;
-  contexts: Record<string, string>;
-  force?: boolean;
-}) => {
-  try {
-    const attempts = [false, true];
-    for (const strict of attempts) {
-      const result = await generateMemorySentence({
-        ...options,
-        force: options.force || strict,
-      });
-      const normalized = normalizeSentence(result);
-      const sentenceCount =
-        normalized.split(/[.!?]+/).filter(Boolean).length || 1;
-      if (
-        normalized.length <= options.maxChars &&
-        sentenceCount <= options.maxSentences &&
-        includesAllWords(normalized, options.words)
-      ) {
-        if (options.words.length === 1) {
-          const occurrences = countWordOccurrences(
-            normalized,
-            options.words[0],
-          );
-          if (occurrences > 1) {
-            continue;
-          }
-        }
-        return normalized;
-      }
-    }
-  } catch {
-    // Fall through to fallback.
-  }
-
-  return buildFallbackSentence(options.words);
-};
 
 const buildWordLookup = (words: string[]) => {
   const lookup = new Map<string, string>();
@@ -141,36 +31,12 @@ const buildWordLookup = (words: string[]) => {
     if (!lookup.has(normalized)) {
       lookup.set(normalized, word);
     }
-    if (normalized.endsWith("ies")) {
-      const variant = `${normalized.slice(0, -3)}y`;
-      if (!lookup.has(variant)) lookup.set(variant, word);
-    }
-    if (normalized.endsWith("es")) {
-      const variant = normalized.slice(0, -2);
-      if (!lookup.has(variant)) lookup.set(variant, word);
-    }
-    if (normalized.endsWith("s")) {
-      const variant = normalized.slice(0, -1);
-      if (!lookup.has(variant)) lookup.set(variant, word);
-    }
   }
   return lookup;
 };
 
-const parseGrouping = (raw: string, words: string[]) => {
-  const lookup = buildWordLookup(words);
-  const attempt = (value: string) => {
-    const parsed = JSON.parse(value) as { groups?: string[][] };
-    const groups = Array.isArray(parsed.groups) ? parsed.groups : [];
-    return groups
-      .map((group) =>
-        group
-          .map((word) => lookup.get(normalizeWordToken(word)) ?? "")
-          .filter(Boolean),
-      )
-      .filter((group) => group.length > 0);
-  };
-
+const parseJSONFromModel = (raw: string) => {
+  const attempt = (value: string) => JSON.parse(value) as { cards?: unknown[] };
   try {
     return attempt(raw);
   } catch {
@@ -178,85 +44,83 @@ const parseGrouping = (raw: string, words: string[]) => {
     const start = trimmed.indexOf("{");
     const end = trimmed.lastIndexOf("}");
     if (start !== -1 && end !== -1 && end > start) {
-      try {
-        return attempt(trimmed.slice(start, end + 1));
-      } catch {
-        return null;
-      }
+      return attempt(trimmed.slice(start, end + 1));
     }
-    return null;
+    throw new Error("invalid_memory_cards_json");
   }
 };
 
-const normalizeGroups = (groups: string[][], words: string[]) => {
-  const seen = new Set<string>();
-  const allowed = new Set(words.map((word) => word.toLowerCase()));
-  const normalized: string[][] = [];
-  for (const group of groups) {
-    const cleaned = group
-      .map((word) => word.trim())
-      .filter(Boolean)
-      .filter((word) => allowed.has(word.toLowerCase()))
-      .filter((word) => {
-        const key = word.toLowerCase();
-        if (seen.has(key)) return false;
-        seen.add(key);
-        return true;
-      })
-      .slice(0, 4);
-    if (cleaned.length > 0) {
-      normalized.push(cleaned);
+const normalizeCards = (raw: unknown[], words: string[]) => {
+  const lookup = buildWordLookup(words);
+  const cards: MemoryCardDraft[] = [];
+
+  for (const value of raw) {
+    if (!value || typeof value !== "object") continue;
+    const item = value as { words?: unknown; sentence?: unknown };
+    if (!Array.isArray(item.words) || typeof item.sentence !== "string") {
+      continue;
     }
+
+    const resolvedWords = item.words
+      .map((word) => (typeof word === "string" ? lookup.get(normalizeWordToken(word)) : ""))
+      .filter(Boolean) as string[];
+    const uniqueWords = Array.from(new Set(resolvedWords)).slice(0, 3);
+    const sentence = normalizeText(item.sentence);
+    if (uniqueWords.length === 0 || !sentence) continue;
+
+    cards.push({
+      words: uniqueWords,
+      sentence,
+    });
   }
 
-  const missing = words.filter((word) => !seen.has(word.toLowerCase()));
-  for (const word of missing) {
-    normalized.push([word]);
-  }
-
-  return normalized;
+  return cards;
 };
 
-export const groupMemoryWords = async (options: {
+export const generateMemoryCards = async (options: {
   words: string[];
+  maxChars: number;
+  maxSentences: number;
+  maxWordsPerCard: number;
   taskDate: string;
-  contexts: Record<string, string>;
+  contexts: Record<string, RawContextRecord[]>;
   force?: boolean;
 }) => {
-  const contextLines = options.words
-    .map((word) => `- ${word}: ${options.contexts[word] || ""}`)
-    .join("\n");
-  const prompt = `words: ${options.words.join(", ")}\ncontexts:\n${contextLines}`;
+  const promptPayload = {
+    words: options.words,
+    max_chars: options.maxChars,
+    max_sentences: options.maxSentences,
+    max_words_per_card: Math.min(3, Math.max(1, options.maxWordsPerCard)),
+    raw_contexts_by_word: options.contexts,
+  };
+  const prompt = JSON.stringify(promptPayload, null, 2);
   const inputHash = createInputHash({
     version: 1,
-    type: "memory_grouping",
-    system: MEMORY_GROUP_PROMPT,
+    type: "memory_cards",
+    system: MEMORY_CARDS_PROMPT,
     prompt,
     model: AI_TEXT_MODEL,
     taskDate: options.taskDate,
   });
-  const key = `MEMORY_GROUP_${options.taskDate}_${inputHash.slice(0, 12)}`;
+  const key = `MEMORY_CARDS_${options.taskDate}_${inputHash.slice(0, 12)}`;
 
   if (!options.force) {
-    const cached = await getCachedGeneration("memory_grouping", inputHash);
+    const cached = await getCachedGeneration("memory_cards", inputHash);
     if (cached) {
-      const parsed = parseGrouping(cached, options.words);
-      if (parsed) {
-        return normalizeGroups(parsed, options.words);
-      }
+      const parsed = parseJSONFromModel(cached);
+      return normalizeCards(parsed.cards ?? [], options.words);
     }
   }
 
-  try {
-    const result = await ai_generateText({
-      system: MEMORY_GROUP_PROMPT,
-      prompt,
-    });
+  const result = await ai_generateText({
+    system: MEMORY_CARDS_PROMPT,
+    prompt,
+  });
 
-    await saveGeneration({
-      type: "memory_grouping",
-      key,
-      inputHash,
+  await saveGeneration({
+    type: "memory_cards",
+    key,
+    inputHash,
     content: result,
     meta: {
       words: options.words,
@@ -264,18 +128,8 @@ export const groupMemoryWords = async (options: {
       model: AI_TEXT_MODEL,
       taskDate: options.taskDate,
     },
-    });
+  });
 
-    const parsed = parseGrouping(result, options.words);
-    if (!parsed) {
-      return options.words.map((word) => [word]);
-    }
-    return normalizeGroups(parsed, options.words);
-  } catch {
-    const fallback: string[][] = [];
-    for (let i = 0; i < options.words.length; i += 4) {
-      fallback.push(options.words.slice(i, i + 4));
-    }
-    return fallback;
-  }
+  const parsed = parseJSONFromModel(result);
+  return normalizeCards(parsed.cards ?? [], options.words);
 };

--- a/src/lib/memory/constants.ts
+++ b/src/lib/memory/constants.ts
@@ -1,29 +1,25 @@
-export const MEMORY_SENTENCE_PROMPT = `
-You are a concise English sentence composer for vocabulary learning.
+export const MEMORY_CARDS_PROMPT = `
+You generate daily vocabulary cards in one pass.
 
-Rules:
-1) Output 1-2 sentences in plain text only.
-2) Must include every word exactly as provided (case-insensitive match is OK).
-3) Keep the sentence(s) simple and natural, avoid rare words.
-4) Aside from the required words, use only Basic English (850-word list) vocabulary.
-5) Avoid introducing any new or advanced words; prefer short everyday verbs and nouns from the Basic English list.
-6) Use each word in the sense indicated by its given context line.
-7) Keep total length within the given max_chars.
-8) Do not add quotes, markdown, or extra explanations.
-`;
+Goal:
+- Return a list of cards.
+- Each card contains 1-3 target words and one short sentence.
+- The sentence must use each listed word in the correct sense from its original context data.
 
-export const MEMORY_GROUP_PROMPT = `
-You are a vocabulary grouping assistant.
+Hard rules:
+1) Output JSON only. No markdown, no explanations.
+2) Use only words from the input word list.
+3) Card words must keep original spelling from input (case-insensitive matching is fine).
+4) Each card "words" length must be 1-3.
+5) For each card, sentence length <= max_chars.
+6) For each card, sentence count <= max_sentences.
+7) Keep English natural, simple, and clear.
+8) The meaning of each word in a sentence must follow the supplied raw context records:
+   - context_line
+   - source_text
+   - context
+   Treat these as original references of sense.
 
-Rules:
-1) Group the given words into small groups for sentence creation.
-2) Each group must contain 1-4 words.
-3) Prefer groups of 2-3 words. Use 1-word groups only when necessary.
-4) Every word must appear exactly once across all groups.
-5) Use the provided context lines to group words by compatible senses.
-6) Do not change word forms (no pluralization, tense changes, or spelling changes).
-7) Output JSON only, no extra text.
-
-Output format:
-{"groups":[["word1","word2"],["word3"],["word4","word5","word6"]]}
+Output schema:
+{"cards":[{"words":["word1","word2"],"sentence":"..."}]}
 `;

--- a/src/lib/memory/task.ts
+++ b/src/lib/memory/task.ts
@@ -1,5 +1,5 @@
 import { addDays, format } from "date-fns";
-import { ensureMemorySentence, groupMemoryWords } from "@/lib/memory/ai-service";
+import { generateMemoryCards } from "@/lib/memory/ai-service";
 import { getMemoryFeed, getMemorySettings } from "@/lib/memory";
 import { getSupabaseClient } from "@/lib/supabase";
 import { dailyTaskOptionsSchema } from "@/lib/schemas/memory";
@@ -13,7 +13,12 @@ type MemoryFeedItemLite = {
   fail_count: number | string;
 };
 
-type WordContextMap = Record<string, string>;
+type RawContextRecord = {
+  context_line: string;
+  source_text: string;
+  context: string;
+  created_at: string;
+};
 
 const isValidDateSlug = (value: string) => /^\d{4}-\d{2}-\d{2}$/.test(value);
 
@@ -25,40 +30,6 @@ const resolveTaskDate = (input?: string) => {
 const resolveTodayDate = (input?: string) => {
   if (input && isValidDateSlug(input)) return input;
   return format(new Date(), "yyyy-MM-dd");
-};
-
-const buildCardPlan = async (
-  items: MemoryFeedItemLite[],
-  taskDate: string,
-  contextMap: WordContextMap,
-  force: boolean | undefined,
-) => {
-  if (items.length === 0) return [];
-
-  const words = items.map((item) => item.word_text).filter(Boolean);
-  const groups = await groupMemoryWords({
-    words,
-    taskDate,
-    contexts: contextMap,
-    force,
-  });
-
-  const lookup = new Map(
-    items.map((item) => [item.word_text.toLowerCase(), item]),
-  );
-
-  return groups.map((group) => {
-    const resolved = group
-      .map((word) => lookup.get(word.toLowerCase()))
-      .filter(Boolean) as MemoryFeedItemLite[];
-
-    const primary = resolved[0] ?? items[0];
-    const extras = resolved.slice(1, 4);
-    return {
-      primary,
-      extras,
-    };
-  });
 };
 
 export type DailyTaskResult = {
@@ -211,50 +182,56 @@ export const generateDailyTask = async (
     throw new Error(entriesError.message);
   }
 
-  const contextById = new Map<string, string>();
+  const contextsByWordId = new Map<string, RawContextRecord[]>();
   for (const entry of entries ?? []) {
     const wordId = entry.word_id as string;
-    if (contextById.has(wordId)) continue;
-    const contextLine =
-      (entry.context_line as string | null) ||
-      (entry.source_text as string | null) ||
-      (entry.context as string | null) ||
-      "";
-    contextById.set(wordId, contextLine.trim());
+    const list = contextsByWordId.get(wordId) ?? [];
+    list.push({
+      context_line: (entry.context_line as string | null) ?? "",
+      source_text: (entry.source_text as string | null) ?? "",
+      context: (entry.context as string | null) ?? "",
+      created_at: (entry.created_at as string | null) ?? "",
+    });
+    contextsByWordId.set(wordId, list);
   }
 
-  const contextMap: WordContextMap = {};
+  const contextMap: Record<string, RawContextRecord[]> = {};
   for (const item of feedItems) {
-    contextMap[item.word_text] = contextById.get(item.word_id) ?? "";
+    contextMap[item.word_text] = contextsByWordId.get(item.word_id) ?? [];
   }
 
-  const plan = await buildCardPlan(feedItems, taskDate, contextMap, force);
+  const plannedCards = await generateMemoryCards({
+    words: feedItems.map((item) => item.word_text).filter(Boolean),
+    maxChars,
+    maxSentences,
+    maxWordsPerCard: Math.min(3, maxExtraWords + 1),
+    taskDate,
+    contexts: contextMap,
+    force,
+  });
+  const itemByWord = new Map(
+    feedItems.map((item) => [item.word_text.toLowerCase(), item]),
+  );
   const cards: DailyTaskResult["cards"] = [];
 
-  for (const entry of plan) {
-    const extras = entry.extras.slice(0, maxExtraWords);
-    const words = [entry.primary.word_text, ...extras.map((extra) => extra.word_text)].filter(
-      Boolean,
-    );
-    const sentenceMax = words.length === 1 ? 1 : maxSentences;
-    const sentence = await ensureMemorySentence({
-      words,
-      maxChars,
-      maxSentences: sentenceMax,
-      taskDate,
-      contexts: Object.fromEntries(
-        words.map((word) => [word, contextMap[word] ?? ""]),
-      ),
-      force,
-    });
+  for (const planned of plannedCards) {
+    const resolved = planned.words
+      .map((word) => itemByWord.get(word.toLowerCase()))
+      .filter(Boolean) as MemoryFeedItemLite[];
+    if (resolved.length === 0) continue;
+
+    const primary = resolved[0];
+    const extras = resolved.slice(1, 3);
+    const words = [primary.word_text, ...extras.map((extra) => extra.word_text)];
+    const sentence = planned.sentence;
     const charCount = sentence.length;
-    const wordIds = [entry.primary.word_id, ...extras.map((extra) => extra.word_id)];
+    const wordIds = [primary.word_id, ...extras.map((extra) => extra.word_id)];
 
     const { data: cardRow, error: cardError } = await supabase
       .from("word_memory_cards")
       .insert({
         task_id: taskId,
-        primary_word_id: entry.primary.word_id,
+        primary_word_id: primary.word_id,
         extra_word_ids: extras.map((extra) => extra.word_id),
         sentence,
         word_count: words.length,
@@ -275,6 +252,10 @@ export const generateDailyTask = async (
       word_count: words.length,
       char_count: charCount,
     });
+  }
+
+  if (cards.length === 0) {
+    throw new Error("no_memory_cards");
   }
 
   const { data: finalTask, error: finalError } = await supabase


### PR DESCRIPTION
## Summary
- replace two-step daily task generation (grouping + per-card sentence) with one AI call
- pass raw context records (context_line/source_text/context) per word to guide sense usage
- enforce 1-3 words per card in prompt and normalization
- add ai cache type for memory_cards

## Validation
- pnpm run lint
- pnpm run typecheck