### PR TITLE
feat: prefetch and autoplay daily sentence/word audio

### DIFF
--- a/src/app/words/daily/daily-task-client.tsx
+++ b/src/app/words/daily/daily-task-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Languages, Volume2 } from "lucide-react";
 import { WordCardSheet } from "@/app/words/[slug]/components/word-card-sheet";
 import {
@@ -133,6 +133,8 @@ export const DailyTaskClient = ({
     useState(false);
   const sentenceAudioRef = useRef<HTMLAudioElement>(null);
   const sheetAudioRef = useRef<HTMLAudioElement>(null);
+  const sentenceAudioCacheRef = useRef<Record<string, HTMLAudioElement>>({});
+  const wordAudioCacheRef = useRef<Record<string, HTMLAudioElement>>({});
   const bundleCacheRef = useRef<BundleCache>({});
   const contextCacheRef = useRef<
     Record<string, { linesKey: string; translations: string[] }>
@@ -145,6 +147,7 @@ export const DailyTaskClient = ({
   const pendingReviewRef = useRef<Set<string>>(new Set());
   const masteredCardsRef = useRef<Set<string>>(new Set());
   const currentVisitOpenedRef = useRef(false);
+  const pendingSentenceAutoPlayRef = useRef(false);
   const navLockRef = useRef(false);
   const sheetRequestIdRef = useRef(0);
   const [pendingVersion, setPendingVersion] = useState(0);
@@ -198,12 +201,47 @@ export const DailyTaskClient = ({
     return `/api/speech/${sheetWordText}`;
   }, [sheetWordText]);
 
+  const preloadAudio = useCallback(
+    (cache: MutableRefObject<Record<string, HTMLAudioElement>>, src?: string) => {
+      if (!src || cache.current[src]) return;
+      const audio = new Audio();
+      audio.preload = "auto";
+      audio.src = src;
+      audio.load();
+      cache.current[src] = audio;
+    },
+    [],
+  );
+
+  const playSentenceAudio = useCallback(
+    (src?: string) => {
+      if (!src || !sentenceAudioRef.current) return;
+      if (sentenceAudioStatus !== "idle") return;
+      setSentenceAudioStatus("loading");
+      sentenceAudioRef.current.src = src;
+      const playResult = sentenceAudioRef.current.play();
+      if (playResult && typeof playResult.catch === "function") {
+        playResult.catch(() => setSentenceAudioStatus("idle"));
+      }
+    },
+    [sentenceAudioStatus],
+  );
+
   useEffect(() => {
     currentVisitOpenedRef.current = false;
+    pendingSentenceAutoPlayRef.current = true;
     setSentenceAudioStatus("idle");
     setSentenceTranslationOpen(false);
     setSentenceTranslationLoading(false);
   }, [currentCardIndex, phase]);
+
+  useEffect(() => {
+    if (!sentenceAudioSrc) return;
+    if (!pendingSentenceAutoPlayRef.current) return;
+    if (sentenceAudioStatus !== "idle") return;
+    pendingSentenceAutoPlayRef.current = false;
+    playSentenceAudio(sentenceAudioSrc);
+  }, [sentenceAudioSrc, sentenceAudioStatus, playSentenceAudio]);
 
   useEffect(() => {
     flushPendingEvents();
@@ -517,8 +555,9 @@ export const DailyTaskClient = ({
           () => undefined,
         );
       }
+      preloadAudio(wordAudioCacheRef, `/api/speech/${wordText}`);
     },
-    [loadBundle, loadContextTranslations, wordContexts],
+    [loadBundle, loadContextTranslations, preloadAudio, wordContexts],
   );
 
   useEffect(() => {
@@ -530,12 +569,14 @@ export const DailyTaskClient = ({
               const wordText = card.words[index] || "";
               prefetchWordData(wordId, wordText);
             });
+            preloadAudio(sentenceAudioCacheRef, sentenceAudioSrc);
           })
         : window.setTimeout(() => {
             card.word_ids.forEach((wordId, index) => {
               const wordText = card.words[index] || "";
               prefetchWordData(wordId, wordText);
             });
+            preloadAudio(sentenceAudioCacheRef, sentenceAudioSrc);
           }, 100);
 
     return () => {
@@ -545,7 +586,7 @@ export const DailyTaskClient = ({
         clearTimeout(handle as number);
       }
     };
-  }, [card, prefetchWordData]);
+  }, [card, prefetchWordData, preloadAudio, sentenceAudioSrc]);
 
   const handleOpenSheet = (wordId: string, wordText: string) => {
     if (isProcessing) return;
@@ -635,14 +676,7 @@ export const DailyTaskClient = ({
   };
 
   const handlePlaySentence = () => {
-    if (!sentenceAudioSrc || !sentenceAudioRef.current) return;
-    if (sentenceAudioStatus !== "idle") return;
-    setSentenceAudioStatus("loading");
-    sentenceAudioRef.current.src = sentenceAudioSrc;
-    const playResult = sentenceAudioRef.current.play();
-    if (playResult && typeof playResult.catch === "function") {
-      playResult.catch(() => setSentenceAudioStatus("idle"));
-    }
+    playSentenceAudio(sentenceAudioSrc);
   };
 
   const handleToggleSentenceTranslation = async () => {


### PR DESCRIPTION
### Motivation
- The daily task flow only prefetched the word card audio, causing repeated network loads for sentence and word pronunciations and preventing in-memory reuse.
- Sentences should be read automatically when a new card is shown, matching the existing word-card open behavior.

### Description
- Added in-memory audio caches `sentenceAudioCacheRef` and `wordAudioCacheRef` and a `preloadAudio` helper that loads audio via `new Audio()` to keep pronunciations cached.
- Introduced a shared `playSentenceAudio` helper and updated `handlePlaySentence` to reuse it for manual playback.
- Implemented automatic sentence playback on card transitions using `pendingSentenceAutoPlayRef` and an effect that triggers `playSentenceAudio` when the new `sentenceAudioSrc` is available and idle.
- Prefetch now runs during idle time to call `prefetchWordData` for bundles/translations and to `preloadAudio` both word pronunciation endpoints and the sentence speech endpoint, and `MutableRefObject` was added to imports; changes are in `src/app/words/daily/daily-task-client.tsx`.

### Testing
- Ran `pnpm run lint` which completed successfully with no ESLint warnings or errors.
- Ran `pnpm run typecheck` which failed due to missing modules (`@ai-sdk/provider` and `@ai-sdk/provider-utils`) in the environment and is unrelated to the audio changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987042560f08333b6abff3e8b01771c)