### PR TITLE
fix: add ai-sdk provider dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@ai-sdk/openai": "^2.0.89",
     "@ai-sdk/openai-compatible": "^1.0.31",
+    "@ai-sdk/provider": "^2.0.1",
+    "@ai-sdk/provider-utils": "^3.0.20",
     "@octokit/rest": "^21.1.1",
     "@reactuses/core": "^6.1.11",
     "@supabase/supabase-js": "^2.91.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ dependencies:
   '@ai-sdk/openai-compatible':
     specifier: ^1.0.31
     version: 1.0.31(zod@3.25.76)
+  '@ai-sdk/provider':
+    specifier: ^2.0.1
+    version: 2.0.1
+  '@ai-sdk/provider-utils':
+    specifier: ^3.0.20
+    version: 3.0.20(zod@3.25.76)
   '@octokit/rest':
     specifier: ^21.1.1
     version: 21.1.1


### PR DESCRIPTION
### Motivation

- Fix TypeScript build errors complaining about missing `@ai-sdk/provider` and related types during deployment by making the packages direct dependencies.

### Description

- Add `@ai-sdk/provider@^2.0.1` and `@ai-sdk/provider-utils@^3.0.20` to `dependencies` in `package.json`.
- Update `pnpm-lock.yaml` to include the new direct dependency entries for the two packages.
- Commit the dependency updates so CI/build tooling sees the direct deps.

### Testing

- Ran `pnpm run lint` which completed successfully with no ESLint warnings or errors. 
- Ran `pnpm run typecheck` which failed with `TS2307: Cannot find module '@ai-sdk/provider'` and `TS2307: Cannot find module '@ai-sdk/provider-utils'` reported from `src/lib/ai/index.ts`, indicating the typecheck still fails until the packages are available in the local install.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69870df0cb2c8333afcab74b7077ce25)