### PR TITLE
feat(api): support SSE streaming in words translate endpoint

### DIFF
--- a/src/app/api/words/translate/route.ts
+++ b/src/app/api/words/translate/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { AI_TEXT_BASE_URL, AI_TEXT_MODEL, AI_TEXT_TOKEN } from "@/lib/ai";
 import { enforceRateLimit, requireSupabaseAuth } from "@/lib/middleware/security";
+import { SENTENCE_TRANSLATE_PROMPT } from "@/lib/words/constants";
 import { translateSentence } from "@/lib/words/ai-service";
 import { sentenceTranslationRequestSchema } from "@/lib/schemas/words";
 
@@ -26,6 +28,63 @@ export async function POST(request: NextRequest) {
       { error: "text is required" },
       { status: 400 },
     );
+  }
+
+  if (parsedPayload.data.stream) {
+    const baseUrl = AI_TEXT_BASE_URL;
+    const token = AI_TEXT_TOKEN;
+
+    if (!baseUrl || !token) {
+      return NextResponse.json(
+        {
+          error:
+            "AI_TEXT_BASE_URL or AI_TEXT_TOKEN is not configured (or fallback AI_BASE_URL and AI_TOKEN)",
+        },
+        { status: 500 },
+      );
+    }
+
+    const upstream = await fetch(
+      new URL("/v1/chat/completions", baseUrl).toString(),
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          model: AI_TEXT_MODEL,
+          stream: true,
+          messages: [
+            { role: "system", content: SENTENCE_TRANSLATE_PROMPT },
+            {
+              role: "user",
+              content: `sentence: ${parsedPayload.data.text}`,
+            },
+          ],
+        }),
+      },
+    );
+
+    if (!upstream.ok) {
+      const errorText = await upstream.text();
+      return new NextResponse(errorText, {
+        status: upstream.status,
+        headers: {
+          "Content-Type": upstream.headers.get("content-type") || "text/plain",
+        },
+      });
+    }
+
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: {
+        "Content-Type": "text/event-stream; charset=utf-8",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        "X-Accel-Buffering": "no",
+      },
+    });
   }
 
   const content = await translateSentence(parsedPayload.data.text, {

--- a/src/lib/schemas/words.ts
+++ b/src/lib/schemas/words.ts
@@ -65,6 +65,7 @@ export const sentenceTranslationRequestSchema = z
   .object({
     text: nonEmptyTrimmedStringSchema,
     force: optionalBooleanSchema,
+    stream: optionalBooleanSchema,
   })
   .passthrough();
 


### PR DESCRIPTION
## Summary
- add optional `stream` to sentence translation request schema
- extend `/api/words/translate` to support SSE passthrough when `stream=true`
- keep existing JSON response behavior when `stream` is omitted or false
## Validation
- pnpm run lint
- pnpm run typecheck