### PR TITLE
fix(api): honor raw stream flag in words translate endpoint

### DIFF
--- a/src/app/api/words/translate/route.ts
+++ b/src/app/api/words/translate/route.ts
@@ -21,6 +21,11 @@ export async function POST(request: NextRequest) {
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
+  const payloadObject =
+    payload && typeof payload === "object"
+      ? (payload as Record<string, unknown>)
+      : {};
+  const streamRequested = payloadObject.stream === true;
 
   const parsedPayload = sentenceTranslationRequestSchema.safeParse(payload);
   if (!parsedPayload.success) {
@@ -30,7 +35,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  if (parsedPayload.data.stream) {
+  if (streamRequested) {
     const baseUrl = AI_TEXT_BASE_URL;
     const token = AI_TEXT_TOKEN;
 


### PR DESCRIPTION
Summary: read stream flag from raw payload before schema parsing; preserve streaming behavior when clients send explicit stream=true. Validation: pnpm run lint; pnpm run typecheck.