### PR TITLE
fix(api): normalize streaming upstream URL and validate SSE response

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,5 @@
 - 每次变更后，运行 pnpm run lint & pnpm run typecheck 检查语法问题
 
 - commit/push 时必须使用 Conventional Commits 规范的 commit message
+
+- 创建或编辑 PR description 时必须使用单行文本（禁止换行符），避免 DW 显示异常

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -20,7 +20,8 @@ const ensureAllowedModel = (model: string) => {
 };
 
 const buildUpstreamUrl = (baseUrl: string) => {
-  return new URL("/v1/chat/completions", baseUrl).toString();
+  const normalized = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  return new URL("chat/completions", normalized).toString();
 };
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/words/translate/route.ts
+++ b/src/app/api/words/translate/route.ts
@@ -5,6 +5,11 @@ import { SENTENCE_TRANSLATE_PROMPT } from "@/lib/words/constants";
 import { translateSentence } from "@/lib/words/ai-service";
 import { sentenceTranslationRequestSchema } from "@/lib/schemas/words";
 
+const buildUpstreamUrl = (baseUrl: string) => {
+  const normalized = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  return new URL("chat/completions", normalized).toString();
+};
+
 export async function POST(request: NextRequest) {
   const auth = await requireSupabaseAuth(request);
   if (!auth.ok) {
@@ -26,6 +31,10 @@ export async function POST(request: NextRequest) {
       ? (payload as Record<string, unknown>)
       : {};
   const streamRequested = payloadObject.stream === true;
+  console.log("[words/translate] request mode", {
+    streamRequested,
+    hasText: typeof payloadObject.text === "string" && payloadObject.text.length > 0,
+  });
 
   const parsedPayload = sentenceTranslationRequestSchema.safeParse(payload);
   if (!parsedPayload.success) {
@@ -49,27 +58,25 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const upstream = await fetch(
-      new URL("/v1/chat/completions", baseUrl).toString(),
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({
-          model: AI_TEXT_MODEL,
-          stream: true,
-          messages: [
-            { role: "system", content: SENTENCE_TRANSLATE_PROMPT },
-            {
-              role: "user",
-              content: `sentence: ${parsedPayload.data.text}`,
-            },
-          ],
-        }),
+    const upstream = await fetch(buildUpstreamUrl(baseUrl), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+        Authorization: `Bearer ${token}`,
       },
-    );
+      body: JSON.stringify({
+        model: AI_TEXT_MODEL,
+        stream: true,
+        messages: [
+          { role: "system", content: SENTENCE_TRANSLATE_PROMPT },
+          {
+            role: "user",
+            content: `sentence: ${parsedPayload.data.text}`,
+          },
+        ],
+      }),
+    });
 
     if (!upstream.ok) {
       const errorText = await upstream.text();
@@ -80,6 +87,25 @@ export async function POST(request: NextRequest) {
         },
       });
     }
+    const upstreamContentType = upstream.headers.get("content-type") || "";
+    if (!upstreamContentType.includes("text/event-stream")) {
+      const body = await upstream.text();
+      console.log("[words/translate] upstream returned non-stream body", {
+        contentType: upstreamContentType,
+        preview: body.slice(0, 300),
+      });
+      return NextResponse.json(
+        {
+          error: "Upstream did not return event-stream",
+          contentType: upstreamContentType,
+        },
+        { status: 502 },
+      );
+    }
+    console.log("[words/translate] upstream stream ready", {
+      status: upstream.status,
+      contentType: upstreamContentType,
+    });
 
     return new Response(upstream.body, {
       status: upstream.status,


### PR DESCRIPTION
Summary: normalize upstream chat/completions URL building for stream calls, add SSE content-type guard and diagnostics in words translate API, and document single-line PR description rule in AGENTS.md. Validation: pnpm run lint; pnpm run typecheck.