### PR TITLE
feat(words): show mastered/unmastered counts in daily progress bar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -320,14 +320,18 @@ body {
   top: 0;
   left: 0;
   width: 100%;
-  height: 3px;
+  height: 24px;
   background: color-mix(in srgb, var(--accent-warm) 12%, transparent);
   z-index: 60;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .daily-date {
   position: fixed;
-  top: 16px;
+  top: 34px;
   left: 50%;
   transform: translateX(-50%);
   color: var(--text-muted);
@@ -338,9 +342,25 @@ body {
 }
 
 .daily-progress-bar {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
   height: 100%;
   background: var(--accent-warm);
   transition: width 420ms ease;
+  z-index: 0;
+}
+
+.daily-progress-text {
+  position: relative;
+  z-index: 1;
+  pointer-events: none;
+  color: var(--foreground);
+  font-size: 0.68rem;
+  line-height: 1;
+  letter-spacing: 0.08em;
+  white-space: nowrap;
 }
 
 .daily-core {

--- a/src/app/words/daily/daily-task-client.tsx
+++ b/src/app/words/daily/daily-task-client.tsx
@@ -187,6 +187,12 @@ export const DailyTaskClient = ({
       : (cardIndexById.get(reviewQueue[reviewCursor] ?? "") ?? 0);
   const card = cards[currentCardIndex];
   const totalCards = cards.length;
+  const masteredCount = completed
+    ? totalCards
+    : Math.min(totalCards, masteredCardsRef.current.size);
+  const unmasteredCount = Math.max(0, totalCards - masteredCount);
+  const progressPercent =
+    totalCards > 0 ? Math.min(100, (masteredCount / totalCards) * 100) : 0;
   const isLast = index === totalCards - 1;
   const wordMap = useMemo(() => {
     const map = new Map<string, string>();
@@ -855,21 +861,23 @@ export const DailyTaskClient = ({
 
   return (
     <div className="daily-page">
-      <div className="daily-progress">
+      <div
+        className="daily-progress"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={totalCards}
+        aria-valuenow={masteredCount}
+        aria-valuetext={`已背 ${masteredCount}，未背 ${unmasteredCount}`}
+      >
         <div
           className="daily-progress-bar"
           style={{
-            width:
-              totalCards > 0
-                ? `${Math.min(
-                    100,
-                    ((completed ? totalCards : masteredCardsRef.current.size) /
-                      totalCards) *
-                      100,
-                  )}%`
-                : "0%",
+            width: `${progressPercent}%`,
           }}
         />
+        <div className="daily-progress-text" aria-hidden>
+          已背 {masteredCount} · 未背 {unmasteredCount}
+        </div>
       </div>
       <div className="daily-date">{date}</div>
       {confettiActive && (

--- a/src/app/words/daily/daily-task-page-client.tsx
+++ b/src/app/words/daily/daily-task-page-client.tsx
@@ -67,6 +67,9 @@ export const DailyTaskPageClient = () => {
       <div className="daily-page">
         <div className="daily-progress">
           <div className="daily-progress-bar" style={{ width: "0%" }} />
+          <div className="daily-progress-text" aria-hidden>
+            已背 0 · 未背 0
+          </div>
         </div>
         <div className="daily-date">{localDate}</div>
         <div className="daily-shell">
@@ -81,6 +84,9 @@ export const DailyTaskPageClient = () => {
       <div className="daily-page">
         <div className="daily-progress">
           <div className="daily-progress-bar" style={{ width: "0%" }} />
+          <div className="daily-progress-text" aria-hidden>
+            已背 0 · 未背 0
+          </div>
         </div>
         <div className="daily-date">{localDate}</div>
         <div className="daily-shell daily-shell--loading">


### PR DESCRIPTION
This PR adds in-bar mastered/unmastered counts to the words/daily top task progress bar, increases bar height for readability, updates loading/error placeholders to match, and keeps existing task progress semantics unchanged.