### PR TITLE
feat(markdown): support Mermaid rendering with beautiful-mermaid

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/rss": "^0.0.32",
     "@wooorm/starry-night": "^3.9.0",
     "ai": "^5.0.123",
+    "beautiful-mermaid": "^0.1.3",
     "date-fns": "^4.1.0",
     "github-markdown-css": "^5.8.1",
     "gray-matter": "^4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ dependencies:
   ai:
     specifier: ^5.0.123
     version: 5.0.123(zod@3.25.76)
+  beautiful-mermaid:
+    specifier: ^0.1.3
+    version: 0.1.3
   date-fns:
     specifier: ^4.1.0
     version: 4.1.0
@@ -175,6 +178,17 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
     dev: true
+
+  /@dagrejs/dagre@1.1.8:
+    resolution: {integrity: sha512-5SEDlndt4W/LaVzPYJW+bSmSEZc9EzTf8rJ20WCKvjS5EAZAN0b+x0Yww7VMT4R3Wootkg+X9bUfUxazYw6Blw==}
+    dependencies:
+      '@dagrejs/graphlib': 2.2.4
+    dev: false
+
+  /@dagrejs/graphlib@2.2.4:
+    resolution: {integrity: sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==}
+    engines: {node: '>17.0.0'}
+    dev: false
 
   /@emnapi/core@1.8.1:
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -2139,6 +2153,12 @@ packages:
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
+
+  /beautiful-mermaid@0.1.3:
+    resolution: {integrity: sha512-lVEHCnlVLtVRbO03T+D9kY5BZlkpvFU6F18LEu2N2VLB0eo5evG1FJWg3SvREErKY+zZ7j9f+cNsgtiOhYI2Nw==}
+    dependencies:
+      '@dagrejs/dagre': 1.1.8
+    dev: false
 
   /before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,6 +23,12 @@
     }
   }
 
+  .mermaid-diagram svg {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+
   /* Hashtag styles */
   .hashtag {
     display: inline-flex;

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -6,6 +6,7 @@ import { convertAttachmentUrls } from "@/lib/attachment";
 import type { ReactNode } from "react";
 import Image from "next/image";
 import { format } from "date-fns";
+import { renderMermaid, THEMES } from "beautiful-mermaid";
 
 interface MarkdownRendererProps {
   content: string;
@@ -57,7 +58,7 @@ function processChildren(children: ReactNode): ReactNode {
     : processHashtagsInText(children);
 }
 
-export default function MarkdownRenderer({
+export default async function MarkdownRenderer({
   content,
   date,
 }: MarkdownRendererProps) {
@@ -86,6 +87,35 @@ export default function MarkdownRenderer({
           ),
           p: ({ children }) => <p>{processChildren(children)}</p>,
           li: ({ children }) => <li>{processChildren(children)}</li>,
+          code: async ({ className, children, ...props }) => {
+            const language = className?.replace("language-", "");
+            if (language === "mermaid") {
+              const mermaidText = String(children).replace(/\n$/, "");
+              try {
+                const svg = await renderMermaid(mermaidText, {
+                  ...THEMES["github-light"],
+                  font: "Inter",
+                });
+                return (
+                  <div
+                    className="my-6 overflow-x-auto mermaid-diagram"
+                    dangerouslySetInnerHTML={{ __html: svg }}
+                  />
+                );
+              } catch {
+                return (
+                  <pre className="my-4 rounded bg-red-50 p-3 text-sm text-red-700 overflow-x-auto">
+                    Mermaid render failed.\n{mermaidText}
+                  </pre>
+                );
+              }
+            }
+            return (
+              <code className={className} {...props}>
+                {children}
+              </code>
+            );
+          },
           img: ({ src, alt }) => {
             return (
               <div className="flex flex-col items-center my-4">

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -58,6 +58,38 @@ function processChildren(children: ReactNode): ReactNode {
     : processHashtagsInText(children);
 }
 
+function extractText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  if (!value) return "";
+
+  if (Array.isArray(value)) {
+    return value.map((item) => extractText(item)).join("");
+  }
+
+  if (typeof value === "object") {
+    const maybeNode = value as {
+      value?: unknown;
+      children?: unknown;
+      props?: { children?: unknown };
+    };
+
+    if (typeof maybeNode.value === "string") {
+      return maybeNode.value;
+    }
+
+    if (maybeNode.children !== undefined) {
+      return extractText(maybeNode.children);
+    }
+
+    if (maybeNode.props?.children !== undefined) {
+      return extractText(maybeNode.props.children);
+    }
+  }
+
+  return "";
+}
+
 export default async function MarkdownRenderer({
   content,
   date,
@@ -87,10 +119,12 @@ export default async function MarkdownRenderer({
           ),
           p: ({ children }) => <p>{processChildren(children)}</p>,
           li: ({ children }) => <li>{processChildren(children)}</li>,
-          code: async ({ className, children, ...props }) => {
+          code: async ({ className, children, node, ...props }) => {
             const language = className?.replace("language-", "");
             if (language === "mermaid") {
-              const mermaidText = String(children).replace(/\n$/, "");
+              const mermaidText = (extractText(node) || extractText(children))
+                .replace(/^\n+|\n+$/g, "")
+                .trim();
               try {
                 const svg = await renderMermaid(mermaidText, {
                   ...THEMES["github-light"],


### PR DESCRIPTION
## Summary
- add `beautiful-mermaid` as Mermaid rendering engine
- render fenced mermaid code blocks in Markdown as SVG
- add Mermaid diagram responsive style in global CSS
- keep non-Mermaid code rendering unchanged with existing highlighter

## Validation
- pnpm typecheck
- pnpm lint

## Notes
- fallback to readable error block if Mermaid rendering fails
