### PR TITLE
feat(markdown): adapt Mermaid rendering for dark mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -108,6 +108,25 @@
     width: 100%;
     height: auto;
     display: block;
+    --bg: transparent !important;
+    --fg: #27272a !important;
+    --line: #52525b !important;
+    --accent: #2563eb !important;
+    --muted: #71717a !important;
+    --surface: #f4f4f5 !important;
+    --border: #d4d4d8 !important;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .mermaid-diagram svg {
+      --bg: transparent !important;
+      --fg: #e4e4e7 !important;
+      --line: #a1a1aa !important;
+      --accent: #93c5fd !important;
+      --muted: #a1a1aa !important;
+      --surface: #1f1f23 !important;
+      --border: #3f3f46 !important;
+    }
   }
 
   @media (max-width: 768px) {

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -127,8 +127,9 @@ export default async function MarkdownRenderer({
                 .trim();
               try {
                 const svg = await renderMermaid(mermaidText, {
-                  ...THEMES["github-light"],
+                  ...THEMES["zinc-light"],
                   font: "Inter",
+                  transparent: true,
                 });
                 return (
                   <div


### PR DESCRIPTION
## Summary
- adapt Mermaid diagrams for dark mode in markdown posts
- render Mermaid SVG with transparent background
- apply light/dark CSS variable palettes to Mermaid SVG (`--fg`, `--line`, `--accent`, `--muted`, `--surface`, `--border`)
- keep Mermaid responsive width behavior

## Validation
- pnpm lint
- pnpm typecheck
