### PR TITLE
feat(markdown): add zoomable lightbox for Mermaid diagrams

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -104,7 +104,31 @@
     margin-block: 1.2em;
   }
 
-  .mermaid-diagram svg {
+  .mermaid-zoomable-trigger {
+    width: 100%;
+    border: 0;
+    background: transparent;
+    padding: 0;
+    text-align: left;
+    cursor: zoom-in;
+    position: relative;
+  }
+
+  .mermaid-zoomable-hint {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    font-size: 0.72rem;
+    color: #71717a;
+    background: rgba(255, 255, 255, 0.85);
+    border: 1px solid #e4e4e7;
+    border-radius: 999px;
+    padding: 0.15rem 0.5rem;
+    z-index: 2;
+  }
+
+  .mermaid-diagram svg,
+  .mermaid-lightbox-content svg {
     width: 100%;
     height: auto;
     display: block;
@@ -117,8 +141,61 @@
     --border: #d4d4d8 !important;
   }
 
+  .mermaid-lightbox {
+    position: fixed;
+    inset: 0;
+    background: rgba(10, 10, 12, 0.7);
+    z-index: 60;
+    display: flex;
+    flex-direction: column;
+    padding: 1rem;
+    gap: 0.75rem;
+  }
+
+  .mermaid-lightbox-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
+  .mermaid-lightbox-toolbar button {
+    border: 1px solid #d4d4d8;
+    background: #ffffff;
+    color: #27272a;
+    border-radius: 8px;
+    padding: 0.35rem 0.65rem;
+    font-size: 0.82rem;
+    cursor: pointer;
+  }
+
+  .mermaid-lightbox-stage {
+    flex: 1;
+    overflow: hidden;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.96);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    touch-action: none;
+    cursor: grab;
+  }
+
+  .mermaid-lightbox-content {
+    transform-origin: center center;
+    max-width: min(1200px, 96vw);
+    width: 100%;
+    will-change: transform;
+  }
+
   @media (prefers-color-scheme: dark) {
-    .mermaid-diagram svg {
+    .mermaid-zoomable-hint {
+      color: #d4d4d8;
+      background: rgba(24, 24, 27, 0.85);
+      border-color: #3f3f46;
+    }
+
+    .mermaid-diagram svg,
+    .mermaid-lightbox-content svg {
       --bg: transparent !important;
       --fg: #e4e4e7 !important;
       --line: #a1a1aa !important;
@@ -126,6 +203,16 @@
       --muted: #a1a1aa !important;
       --surface: #1f1f23 !important;
       --border: #3f3f46 !important;
+    }
+
+    .mermaid-lightbox-stage {
+      background: rgba(17, 17, 22, 0.96);
+    }
+
+    .mermaid-lightbox-toolbar button {
+      border-color: #3f3f46;
+      background: #18181b;
+      color: #e4e4e7;
     }
   }
 

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -7,6 +7,7 @@ import type { ReactNode } from "react";
 import Image from "next/image";
 import { format } from "date-fns";
 import { renderMermaid, THEMES } from "beautiful-mermaid";
+import MermaidZoomable from "./MermaidZoomable";
 
 interface MarkdownRendererProps {
   content: string;
@@ -131,12 +132,7 @@ export default async function MarkdownRenderer({
                   font: "Inter",
                   transparent: true,
                 });
-                return (
-                  <div
-                    className="my-6 overflow-x-auto mermaid-diagram"
-                    dangerouslySetInnerHTML={{ __html: svg }}
-                  />
-                );
+                return <MermaidZoomable svg={svg} />;
               } catch {
                 return (
                   <pre className="my-4 rounded bg-red-50 p-3 text-sm text-red-700 overflow-x-auto">

--- a/src/components/MermaidZoomable.tsx
+++ b/src/components/MermaidZoomable.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+type MermaidZoomableProps = {
+  svg: string;
+};
+
+const MIN_SCALE = 0.6;
+const MAX_SCALE = 4;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
+export default function MermaidZoomable({ svg }: MermaidZoomableProps) {
+  const [open, setOpen] = useState(false);
+  const [scale, setScale] = useState(1);
+  const [translate, setTranslate] = useState({ x: 0, y: 0 });
+  const dragRef = useRef<{ x: number; y: number; active: boolean } | null>(null);
+  const pinchRef = useRef<{ distance: number; scale: number } | null>(null);
+
+  const transform = useMemo(
+    () => `translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
+    [translate, scale],
+  );
+
+  const resetView = () => {
+    setScale(1);
+    setTranslate({ x: 0, y: 0 });
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="mermaid-diagram mermaid-zoomable-trigger"
+        onClick={() => {
+          resetView();
+          setOpen(true);
+        }}
+        aria-label="放大查看 Mermaid 图"
+      >
+        <span className="mermaid-zoomable-hint">点击放大</span>
+        <span dangerouslySetInnerHTML={{ __html: svg }} />
+      </button>
+
+      {open && (
+        <div className="mermaid-lightbox" onClick={() => setOpen(false)}>
+          <div className="mermaid-lightbox-toolbar" onClick={(e) => e.stopPropagation()}>
+            <button type="button" onClick={() => setScale((v) => clamp(v - 0.15, MIN_SCALE, MAX_SCALE))}>
+              -
+            </button>
+            <button type="button" onClick={() => setScale((v) => clamp(v + 0.15, MIN_SCALE, MAX_SCALE))}>
+              +
+            </button>
+            <button type="button" onClick={resetView}>100%</button>
+            <button type="button" onClick={() => setOpen(false)}>关闭</button>
+          </div>
+
+          <div
+            className="mermaid-lightbox-stage"
+            onClick={(e) => e.stopPropagation()}
+            onDoubleClick={resetView}
+            onWheel={(event) => {
+              event.preventDefault();
+              const delta = event.deltaY > 0 ? -0.1 : 0.1;
+              setScale((v) => clamp(v + delta, MIN_SCALE, MAX_SCALE));
+            }}
+            onPointerDown={(event) => {
+              dragRef.current = { x: event.clientX, y: event.clientY, active: true };
+            }}
+            onPointerMove={(event) => {
+              if (!dragRef.current?.active) return;
+              const dx = event.clientX - dragRef.current.x;
+              const dy = event.clientY - dragRef.current.y;
+              dragRef.current = { x: event.clientX, y: event.clientY, active: true };
+              setTranslate((p) => ({ x: p.x + dx, y: p.y + dy }));
+            }}
+            onPointerUp={() => {
+              if (dragRef.current) dragRef.current.active = false;
+            }}
+            onPointerCancel={() => {
+              if (dragRef.current) dragRef.current.active = false;
+            }}
+            onTouchStart={(event) => {
+              if (event.touches.length !== 2) return;
+              const a = event.touches.item(0);
+              const b = event.touches.item(1);
+              if (!a || !b) return;
+              const distance = Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
+              pinchRef.current = { distance, scale };
+            }}
+            onTouchMove={(event) => {
+              if (event.touches.length !== 2 || !pinchRef.current) return;
+              const a = event.touches.item(0);
+              const b = event.touches.item(1);
+              if (!a || !b) return;
+              const nextDistance = Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
+              const ratio = nextDistance / pinchRef.current.distance;
+              setScale(clamp(pinchRef.current.scale * ratio, MIN_SCALE, MAX_SCALE));
+            }}
+            onTouchEnd={() => {
+              pinchRef.current = null;
+            }}
+          >
+            <div
+              className="mermaid-lightbox-content"
+              style={{ transform }}
+              dangerouslySetInnerHTML={{ __html: svg }}
+            />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- make Mermaid diagrams clickable like images
- add fullscreen lightbox preview for Mermaid SVG
- support zoom in/out, reset (100%), close
- support pan (drag), wheel zoom, touch pinch zoom, and double-click reset
- keep markdown rendering pipeline unchanged and reusable

## UX
- click Mermaid diagram to open preview
- ESC / overlay click / close button to exit
- toolbar: -, +, 100%, close

## Validation
- pnpm lint
- pnpm typecheck
