### PR TITLE
feat(markdown): stable Mermaid zoom preview with pinch support

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-markdown": "^10.1.0",
+    "react-zoom-pan-pinch": "^3.7.0",
     "rehype-starry-night": "^2.2.0",
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ dependencies:
   react-markdown:
     specifier: ^10.1.0
     version: 10.1.0(@types/react@19.2.9)(react@19.1.0)
+  react-zoom-pan-pinch:
+    specifier: ^3.7.0
+    version: 3.7.0(react-dom@19.1.0)(react@19.1.0)
   rehype-starry-night:
     specifier: ^2.2.0
     version: 2.2.0
@@ -4572,6 +4575,17 @@ packages:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /react-zoom-pan-pinch@3.7.0(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==}
+    engines: {node: '>=8', npm: '>=5'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
     dev: false
 
   /react@19.1.0:

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -180,11 +180,23 @@
     cursor: grab;
   }
 
+  .mermaid-lightbox-wrapper {
+    width: 100%;
+    height: 100%;
+    cursor: grab;
+  }
+
+  .mermaid-lightbox-wrapper:active {
+    cursor: grabbing;
+  }
+
   .mermaid-lightbox-content {
     transform-origin: center center;
-    max-width: min(1200px, 96vw);
-    width: 100%;
     will-change: transform;
+  }
+
+  .mermaid-lightbox-content > div {
+    width: min(1200px, 96vw);
   }
 
   @media (prefers-color-scheme: dark) {

--- a/src/components/MermaidZoomable.tsx
+++ b/src/components/MermaidZoomable.tsx
@@ -1,56 +1,14 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useState } from "react";
+import { TransformComponent, TransformWrapper } from "react-zoom-pan-pinch";
 
 type MermaidZoomableProps = {
   svg: string;
 };
 
-const MIN_SCALE = 0.6;
-const MAX_SCALE = 4;
-
-const clamp = (value: number, min: number, max: number) =>
-  Math.min(max, Math.max(min, value));
-
 export default function MermaidZoomable({ svg }: MermaidZoomableProps) {
   const [open, setOpen] = useState(false);
-  const [scale, setScale] = useState(1);
-  const [translate, setTranslate] = useState({ x: 0, y: 0 });
-  const scaleRef = useRef(1);
-  const translateRef = useRef({ x: 0, y: 0 });
-  const dragRef = useRef<{ x: number; y: number; active: boolean } | null>(null);
-  const touchRef = useRef<
-    | {
-        mode: "pan";
-        startX: number;
-        startY: number;
-        startTranslate: { x: number; y: number };
-      }
-    | {
-        mode: "pinch";
-        startDistance: number;
-        startScale: number;
-      }
-    | null
-  >(null);
-
-  const transform = useMemo(
-    () => `translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
-    [translate, scale],
-  );
-
-  const resetView = () => {
-    setScale(1);
-    setTranslate({ x: 0, y: 0 });
-  };
-
-  useEffect(() => {
-    scaleRef.current = scale;
-  }, [scale]);
-
-  useEffect(() => {
-    translateRef.current = translate;
-  }, [translate]);
 
   useEffect(() => {
     if (!open) return;
@@ -70,10 +28,7 @@ export default function MermaidZoomable({ svg }: MermaidZoomableProps) {
       <button
         type="button"
         className="mermaid-diagram mermaid-zoomable-trigger"
-        onClick={() => {
-          resetView();
-          setOpen(true);
-        }}
+        onClick={() => setOpen(true)}
         aria-label="放大查看 Mermaid 图"
       >
         <span className="mermaid-zoomable-hint">点击放大</span>
@@ -82,124 +37,50 @@ export default function MermaidZoomable({ svg }: MermaidZoomableProps) {
 
       {open && (
         <div className="mermaid-lightbox" onClick={() => setOpen(false)}>
-          <div className="mermaid-lightbox-toolbar" onClick={(e) => e.stopPropagation()}>
-            <button type="button" onClick={() => setScale((v) => clamp(v - 0.15, MIN_SCALE, MAX_SCALE))}>
-              -
-            </button>
-            <button type="button" onClick={() => setScale((v) => clamp(v + 0.15, MIN_SCALE, MAX_SCALE))}>
-              +
-            </button>
-            <button type="button" onClick={resetView}>100%</button>
-            <button type="button" onClick={() => setOpen(false)}>关闭</button>
-          </div>
-
-          <div
-            className="mermaid-lightbox-stage"
-            onClick={(e) => e.stopPropagation()}
-            onDoubleClick={resetView}
-            onWheel={(event) => {
-              event.preventDefault();
-              const delta = event.deltaY > 0 ? -0.1 : 0.1;
-              setScale((v) => clamp(v + delta, MIN_SCALE, MAX_SCALE));
-            }}
-            onPointerDown={(event) => {
-              dragRef.current = { x: event.clientX, y: event.clientY, active: true };
-            }}
-            onPointerMove={(event) => {
-              if (!dragRef.current?.active) return;
-              const dx = event.clientX - dragRef.current.x;
-              const dy = event.clientY - dragRef.current.y;
-              dragRef.current = { x: event.clientX, y: event.clientY, active: true };
-              setTranslate((p) => ({ x: p.x + dx, y: p.y + dy }));
-            }}
-            onPointerUp={() => {
-              if (dragRef.current) dragRef.current.active = false;
-            }}
-            onPointerCancel={() => {
-              if (dragRef.current) dragRef.current.active = false;
-            }}
-            onTouchStart={(event) => {
-              if (event.touches.length === 2) {
-                event.preventDefault();
-                const a = event.touches.item(0);
-                const b = event.touches.item(1);
-                if (!a || !b) return;
-                const startDistance = Math.hypot(
-                  a.clientX - b.clientX,
-                  a.clientY - b.clientY,
-                );
-                touchRef.current = {
-                  mode: "pinch",
-                  startDistance,
-                  startScale: scaleRef.current,
-                };
-                return;
-              }
-
-              if (event.touches.length === 1) {
-                const finger = event.touches.item(0);
-                if (!finger) return;
-                touchRef.current = {
-                  mode: "pan",
-                  startX: finger.clientX,
-                  startY: finger.clientY,
-                  startTranslate: { ...translateRef.current },
-                };
-              }
-            }}
-            onTouchMove={(event) => {
-              if (!touchRef.current) return;
-
-              if (touchRef.current.mode === "pinch" && event.touches.length === 2) {
-                event.preventDefault();
-                const a = event.touches.item(0);
-                const b = event.touches.item(1);
-                if (!a || !b) return;
-                const nextDistance = Math.hypot(
-                  a.clientX - b.clientX,
-                  a.clientY - b.clientY,
-                );
-                const ratio = nextDistance / touchRef.current.startDistance;
-                setScale(clamp(touchRef.current.startScale * ratio, MIN_SCALE, MAX_SCALE));
-                return;
-              }
-
-              if (touchRef.current.mode === "pan" && event.touches.length === 1) {
-                event.preventDefault();
-                const finger = event.touches.item(0);
-                if (!finger) return;
-                const dx = finger.clientX - touchRef.current.startX;
-                const dy = finger.clientY - touchRef.current.startY;
-                setTranslate({
-                  x: touchRef.current.startTranslate.x + dx,
-                  y: touchRef.current.startTranslate.y + dy,
-                });
-              }
-            }}
-            onTouchEnd={(event) => {
-              if (event.touches.length === 0) {
-                touchRef.current = null;
-                return;
-              }
-
-              if (event.touches.length === 1) {
-                const finger = event.touches.item(0);
-                if (!finger) return;
-                touchRef.current = {
-                  mode: "pan",
-                  startX: finger.clientX,
-                  startY: finger.clientY,
-                  startTranslate: { ...translateRef.current },
-                };
-              }
-            }}
+          <TransformWrapper
+            initialScale={1}
+            minScale={0.6}
+            maxScale={4}
+            centerOnInit
+            doubleClick={{ mode: "reset" }}
+            wheel={{ step: 0.15 }}
+            panning={{ velocityDisabled: true }}
+            pinch={{ step: 8 }}
           >
-            <div
-              className="mermaid-lightbox-content"
-              style={{ transform }}
-              dangerouslySetInnerHTML={{ __html: svg }}
-            />
-          </div>
+            {({ zoomIn, zoomOut, resetTransform }) => (
+              <>
+                <div
+                  className="mermaid-lightbox-toolbar"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  <button type="button" onClick={() => zoomOut()}>
+                    -
+                  </button>
+                  <button type="button" onClick={() => zoomIn()}>
+                    +
+                  </button>
+                  <button type="button" onClick={() => resetTransform()}>
+                    100%
+                  </button>
+                  <button type="button" onClick={() => setOpen(false)}>
+                    关闭
+                  </button>
+                </div>
+
+                <div
+                  className="mermaid-lightbox-stage"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  <TransformComponent
+                    wrapperClass="mermaid-lightbox-wrapper"
+                    contentClass="mermaid-lightbox-content"
+                  >
+                    <div dangerouslySetInnerHTML={{ __html: svg }} />
+                  </TransformComponent>
+                </div>
+              </>
+            )}
+          </TransformWrapper>
         </div>
       )}
     </>


### PR DESCRIPTION
## Summary
- make Mermaid diagrams previewable like images in a fullscreen lightbox
- replace custom gesture implementation with mature `react-zoom-pan-pinch`
- support iPhone pinch zoom, pan, double-tap reset, and toolbar zoom controls
- keep Mermaid dark mode color adaptation

## Why this change
- avoids gesture conflicts/flicker from custom touch+pointer handling
- uses community-tested gesture behavior for mobile reliability

## Validation
- pnpm lint
- pnpm typecheck
