### PR TITLE
style(markdown): enlarge Mermaid lightbox canvas area

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -148,8 +148,8 @@
     z-index: 60;
     display: flex;
     flex-direction: column;
-    padding: 1rem;
-    gap: 0.75rem;
+    padding: 0.55rem;
+    gap: 0.45rem;
   }
 
   .mermaid-lightbox-toolbar {
@@ -163,8 +163,8 @@
     background: #ffffff;
     color: #27272a;
     border-radius: 8px;
-    padding: 0.35rem 0.65rem;
-    font-size: 0.82rem;
+    padding: 0.28rem 0.55rem;
+    font-size: 0.78rem;
     cursor: pointer;
   }
 
@@ -184,6 +184,9 @@
     width: 100%;
     height: 100%;
     cursor: grab;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .mermaid-lightbox-wrapper:active {
@@ -193,10 +196,21 @@
   .mermaid-lightbox-content {
     transform-origin: center center;
     will-change: transform;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .mermaid-lightbox-content > div {
-    width: min(1200px, 96vw);
+    width: min(1400px, 98vw);
+    max-height: 90vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .mermaid-lightbox-content > div > svg {
+    max-height: 90vh;
   }
 
   @media (prefers-color-scheme: dark) {
@@ -229,6 +243,29 @@
   }
 
   @media (max-width: 768px) {
+    .mermaid-lightbox {
+      padding: 0.4rem;
+      gap: 0.35rem;
+    }
+
+    .mermaid-lightbox-toolbar {
+      gap: 0.35rem;
+    }
+
+    .mermaid-lightbox-toolbar button {
+      padding: 0.24rem 0.5rem;
+      font-size: 0.75rem;
+    }
+
+    .mermaid-lightbox-content > div {
+      width: min(1400px, 99vw);
+      max-height: 92vh;
+    }
+
+    .mermaid-lightbox-content > div > svg {
+      max-height: 92vh;
+    }
+
     .markdown-body {
       font-size: 1rem;
       line-height: 1.82;


### PR DESCRIPTION
## Summary
- enlarge Mermaid lightbox canvas area, especially on mobile
- reduce lightbox/frame padding so diagram gets more usable space
- increase max preview viewport from conservative sizing to near full screen
- slightly compress toolbar control size to prioritize canvas area

## Validation
- pnpm lint
- pnpm typecheck
