### PR TITLE
fix(markdown): smart-fit Mermaid lightbox to actual diagram content

### DIFF
--- a/src/components/MermaidZoomable.tsx
+++ b/src/components/MermaidZoomable.tsx
@@ -1,14 +1,72 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { TransformComponent, TransformWrapper } from "react-zoom-pan-pinch";
+import { useEffect, useRef, useState } from "react";
+import {
+  TransformComponent,
+  TransformWrapper,
+  type ReactZoomPanPinchRef,
+} from "react-zoom-pan-pinch";
 
 type MermaidZoomableProps = {
   svg: string;
 };
 
+const MIN_SCALE = 0.6;
+const MAX_SCALE = 4;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
 export default function MermaidZoomable({ svg }: MermaidZoomableProps) {
   const [open, setOpen] = useState(false);
+  const transformRef = useRef<ReactZoomPanPinchRef | null>(null);
+  const stageRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+
+  const fitToVisibleContent = () => {
+    const stage = stageRef.current;
+    const container = contentRef.current;
+    const api = transformRef.current;
+    if (!stage || !container || !api) return;
+
+    const svgEl = container.querySelector("svg");
+    if (!svgEl) return;
+
+    try {
+      const bbox = svgEl.getBBox();
+      if (!bbox.width || !bbox.height) return;
+
+      const pad = Math.max(8, Math.min(bbox.width, bbox.height) * 0.04);
+      const viewBox = {
+        x: bbox.x - pad,
+        y: bbox.y - pad,
+        width: bbox.width + pad * 2,
+        height: bbox.height + pad * 2,
+      };
+
+      svgEl.setAttribute(
+        "viewBox",
+        `${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}`,
+      );
+      svgEl.setAttribute("width", String(viewBox.width));
+      svgEl.setAttribute("height", String(viewBox.height));
+
+      const stageWidth = stage.clientWidth;
+      const stageHeight = stage.clientHeight;
+      if (!stageWidth || !stageHeight) return;
+
+      const fittedScale = clamp(
+        Math.min(stageWidth / viewBox.width, stageHeight / viewBox.height) * 0.96,
+        MIN_SCALE,
+        MAX_SCALE,
+      );
+
+      api.setTransform(0, 0, fittedScale, 120);
+      api.centerView(fittedScale, 120);
+    } catch {
+      // Ignore invalid SVG bbox and keep default behavior.
+    }
+  };
 
   useEffect(() => {
     if (!open) return;
@@ -17,9 +75,19 @@ export default function MermaidZoomable({ svg }: MermaidZoomableProps) {
     };
     document.addEventListener("keydown", onKeyDown);
     document.body.style.overflow = "hidden";
+
+    let t2 = 0;
+    const t1 = window.requestAnimationFrame(() => {
+      t2 = window.requestAnimationFrame(() => {
+        fitToVisibleContent();
+      });
+    });
+
     return () => {
       document.removeEventListener("keydown", onKeyDown);
       document.body.style.overflow = "";
+      window.cancelAnimationFrame(t1);
+      if (t2) window.cancelAnimationFrame(t2);
     };
   }, [open]);
 
@@ -38,9 +106,10 @@ export default function MermaidZoomable({ svg }: MermaidZoomableProps) {
       {open && (
         <div className="mermaid-lightbox" onClick={() => setOpen(false)}>
           <TransformWrapper
+            ref={transformRef}
             initialScale={1}
-            minScale={0.6}
-            maxScale={4}
+            minScale={MIN_SCALE}
+            maxScale={MAX_SCALE}
             centerOnInit
             doubleClick={{ mode: "reset" }}
             wheel={{ step: 0.15 }}
@@ -68,6 +137,7 @@ export default function MermaidZoomable({ svg }: MermaidZoomableProps) {
                 </div>
 
                 <div
+                  ref={stageRef}
                   className="mermaid-lightbox-stage"
                   onClick={(event) => event.stopPropagation()}
                 >
@@ -75,7 +145,7 @@ export default function MermaidZoomable({ svg }: MermaidZoomableProps) {
                     wrapperClass="mermaid-lightbox-wrapper"
                     contentClass="mermaid-lightbox-content"
                   >
-                    <div dangerouslySetInnerHTML={{ __html: svg }} />
+                    <div ref={contentRef} dangerouslySetInnerHTML={{ __html: svg }} />
                   </TransformComponent>
                 </div>
               </>


### PR DESCRIPTION
## Summary
- diagnose and fix the "only middle area renders" issue in Mermaid lightbox
- crop oversized Mermaid SVG viewBox to actual graphic bbox
- auto-fit diagram to stage size on open (double rAF after mount)
- keep `react-zoom-pan-pinch` as gesture engine

## Why
Some Mermaid sequence diagrams render with large empty SVG padding. Zooming then scales mostly whitespace.
This patch trims SVG to visible content and performs an automatic fit on open.

## Validation
- pnpm lint
- pnpm typecheck
