### PR TITLE
refactor(markdown): use community lightbox for Mermaid preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "remark-gfm": "^4.0.1",
     "rss": "^1.2.2",
     "tailwind-scrollbar-hide": "^4.0.0",
+    "yet-another-react-lightbox": "^3.29.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ dependencies:
   tailwind-scrollbar-hide:
     specifier: ^4.0.0
     version: 4.0.0(tailwindcss@4.1.18)
+  yet-another-react-lightbox:
+    specifier: ^3.29.0
+    version: 3.29.0(@types/react-dom@19.2.3)(@types/react@19.2.9)(react-dom@19.1.0)(react@19.1.0)
   zod:
     specifier: ^3.25.76
     version: 3.25.76
@@ -1569,7 +1572,6 @@ packages:
       '@types/react': ^19.2.0
     dependencies:
       '@types/react': 19.2.9
-    dev: true
 
   /@types/react@19.2.9:
     resolution: {integrity: sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==}
@@ -5609,6 +5611,26 @@ packages:
 
   /xml@1.0.1:
     resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
+    dev: false
+
+  /yet-another-react-lightbox@3.29.0(@types/react-dom@19.2.3)(@types/react@19.2.9)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-OdjQ7w4Bsl5QHrv+QI6GIFNLYT9WvYLLzeAtLcUPYUaGcA5k1XbQDjyof4CzxLP1XxXsurxBOiFrto1v6zjvrw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@types/react': ^16 || ^17 || ^18 || ^19
+      '@types/react-dom': ^16 || ^17 || ^18 || ^19
+      react: ^16.8.0 || ^17 || ^18 || ^19
+      react-dom: ^16.8.0 || ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@types/react': 19.2.9
+      '@types/react-dom': 19.2.3(@types/react@19.2.9)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
     dev: false
 
   /yocto-queue@0.1.0:

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,8 +5,6 @@
 @import "./code.css" layer(components);
 @import "tailwindcss/utilities.css" layer(utilities);
 @import "tailwind-scrollbar-hide/v4";
-@import "yet-another-react-lightbox/styles.css";
-@import "yet-another-react-lightbox/plugins/zoom.css";
 
 /* 覆盖 prefight */
 @layer components {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,8 @@
 @import "./code.css" layer(components);
 @import "tailwindcss/utilities.css" layer(utilities);
 @import "tailwind-scrollbar-hide/v4";
+@import "yet-another-react-lightbox/styles.css";
+@import "yet-another-react-lightbox/plugins/zoom.css";
 
 /* 覆盖 prefight */
 @layer components {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Inter, Outfit } from "next/font/google";
+import "yet-another-react-lightbox/styles.css";
 import "./globals.css";
 
 const geistSans = Geist({

--- a/src/components/MermaidZoomable.tsx
+++ b/src/components/MermaidZoomable.tsx
@@ -1,95 +1,24 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import {
-  TransformComponent,
-  TransformWrapper,
-  type ReactZoomPanPinchRef,
-} from "react-zoom-pan-pinch";
+import { useMemo, useState } from "react";
+import Lightbox from "yet-another-react-lightbox";
+import Zoom from "yet-another-react-lightbox/plugins/zoom";
 
 type MermaidZoomableProps = {
   svg: string;
 };
 
-const MIN_SCALE = 0.6;
-const MAX_SCALE = 4;
-
-const clamp = (value: number, min: number, max: number) =>
-  Math.min(max, Math.max(min, value));
+function toSvgDataUrl(svg: string): string {
+  const normalized = svg
+    .replace(/\n+/g, " ")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(normalized)}`;
+}
 
 export default function MermaidZoomable({ svg }: MermaidZoomableProps) {
   const [open, setOpen] = useState(false);
-  const transformRef = useRef<ReactZoomPanPinchRef | null>(null);
-  const stageRef = useRef<HTMLDivElement | null>(null);
-  const contentRef = useRef<HTMLDivElement | null>(null);
-
-  const fitToVisibleContent = () => {
-    const stage = stageRef.current;
-    const container = contentRef.current;
-    const api = transformRef.current;
-    if (!stage || !container || !api) return;
-
-    const svgEl = container.querySelector("svg");
-    if (!svgEl) return;
-
-    try {
-      const bbox = svgEl.getBBox();
-      if (!bbox.width || !bbox.height) return;
-
-      const pad = Math.max(8, Math.min(bbox.width, bbox.height) * 0.04);
-      const viewBox = {
-        x: bbox.x - pad,
-        y: bbox.y - pad,
-        width: bbox.width + pad * 2,
-        height: bbox.height + pad * 2,
-      };
-
-      svgEl.setAttribute(
-        "viewBox",
-        `${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}`,
-      );
-      svgEl.setAttribute("width", String(viewBox.width));
-      svgEl.setAttribute("height", String(viewBox.height));
-
-      const stageWidth = stage.clientWidth;
-      const stageHeight = stage.clientHeight;
-      if (!stageWidth || !stageHeight) return;
-
-      const fittedScale = clamp(
-        Math.min(stageWidth / viewBox.width, stageHeight / viewBox.height) * 0.96,
-        MIN_SCALE,
-        MAX_SCALE,
-      );
-
-      api.setTransform(0, 0, fittedScale, 120);
-      api.centerView(fittedScale, 120);
-    } catch {
-      // Ignore invalid SVG bbox and keep default behavior.
-    }
-  };
-
-  useEffect(() => {
-    if (!open) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("keydown", onKeyDown);
-    document.body.style.overflow = "hidden";
-
-    let t2 = 0;
-    const t1 = window.requestAnimationFrame(() => {
-      t2 = window.requestAnimationFrame(() => {
-        fitToVisibleContent();
-      });
-    });
-
-    return () => {
-      document.removeEventListener("keydown", onKeyDown);
-      document.body.style.overflow = "";
-      window.cancelAnimationFrame(t1);
-      if (t2) window.cancelAnimationFrame(t2);
-    };
-  }, [open]);
+  const src = useMemo(() => toSvgDataUrl(svg), [svg]);
 
   return (
     <>
@@ -103,56 +32,20 @@ export default function MermaidZoomable({ svg }: MermaidZoomableProps) {
         <span dangerouslySetInnerHTML={{ __html: svg }} />
       </button>
 
-      {open && (
-        <div className="mermaid-lightbox" onClick={() => setOpen(false)}>
-          <TransformWrapper
-            ref={transformRef}
-            initialScale={1}
-            minScale={MIN_SCALE}
-            maxScale={MAX_SCALE}
-            centerOnInit
-            doubleClick={{ mode: "reset" }}
-            wheel={{ step: 0.15 }}
-            panning={{ velocityDisabled: true }}
-            pinch={{ step: 8 }}
-          >
-            {({ zoomIn, zoomOut, resetTransform }) => (
-              <>
-                <div
-                  className="mermaid-lightbox-toolbar"
-                  onClick={(event) => event.stopPropagation()}
-                >
-                  <button type="button" onClick={() => zoomOut()}>
-                    -
-                  </button>
-                  <button type="button" onClick={() => zoomIn()}>
-                    +
-                  </button>
-                  <button type="button" onClick={() => resetTransform()}>
-                    100%
-                  </button>
-                  <button type="button" onClick={() => setOpen(false)}>
-                    关闭
-                  </button>
-                </div>
-
-                <div
-                  ref={stageRef}
-                  className="mermaid-lightbox-stage"
-                  onClick={(event) => event.stopPropagation()}
-                >
-                  <TransformComponent
-                    wrapperClass="mermaid-lightbox-wrapper"
-                    contentClass="mermaid-lightbox-content"
-                  >
-                    <div ref={contentRef} dangerouslySetInnerHTML={{ __html: svg }} />
-                  </TransformComponent>
-                </div>
-              </>
-            )}
-          </TransformWrapper>
-        </div>
-      )}
+      <Lightbox
+        open={open}
+        close={() => setOpen(false)}
+        slides={[{ src, alt: "mermaid diagram" }]}
+        plugins={[Zoom]}
+        index={0}
+        carousel={{ finite: true, preload: 0 }}
+        controller={{ closeOnBackdropClick: true }}
+        zoom={{ maxZoomPixelRatio: 4, wheelZoomDistanceFactor: 80, pinchZoomDistanceFactor: 80 }}
+        render={{
+          buttonPrev: () => null,
+          buttonNext: () => null,
+        }}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- replace custom Mermaid lightbox implementation with `yet-another-react-lightbox`
- use mature Zoom plugin for pinch/pan/zoom behavior on mobile and desktop
- keep single-slide, non-gallery behavior for documentation context
- continue Mermaid dark-mode adaptation and click-to-open UX

## Notes
- avoids maintaining fragile custom touch/pointer gesture logic
- aligns with community-maintained lightbox behavior and bug fixes

## Validation
- pnpm lint
- pnpm typecheck
