### PR TITLE
refactor(markdown): stable Mermaid lightbox with theme-aligned UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -128,7 +128,7 @@
   }
 
   .yarl__container {
-    backdrop-filter: blur(2px);
+    backdrop-filter: none;
   }
 
   .yarl__slide_image {
@@ -366,8 +366,8 @@
   --accent-warm: #ea580c;
 
   /* Yet Another React Lightbox theme (light) */
-  --yarl__color_backdrop: rgba(253, 253, 247, 0.98);
-  --yarl__container_background_color: rgba(253, 253, 247, 0.98);
+  --yarl__color_backdrop: #ffffff;
+  --yarl__container_background_color: #ffffff;
   --yarl__color_button: rgba(39, 39, 42, 0.9);
   --yarl__color_button_active: rgba(17, 24, 39, 1);
   --yarl__button_filter: none;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -348,6 +348,13 @@
   --text-muted: #6b7280;
   --border-subtle: #e5e7eb;
   --accent-warm: #ea580c;
+
+  /* Yet Another React Lightbox theme (light) */
+  --yarl__color_backdrop: rgba(253, 253, 247, 0.94);
+  --yarl__container_background_color: rgba(253, 253, 247, 0.94);
+  --yarl__color_button: rgba(39, 39, 42, 0.88);
+  --yarl__color_button_active: rgba(17, 24, 39, 1);
+  --yarl__button_filter: none;
 }
 
 a {
@@ -368,6 +375,12 @@ a {
     --foreground: #ededed;
     --text-muted: #9ca3af;
     --border-subtle: #374151;
+
+    /* Yet Another React Lightbox theme (dark) */
+    --yarl__color_backdrop: rgba(10, 10, 12, 0.82);
+    --yarl__container_background_color: rgba(17, 17, 22, 0.96);
+    --yarl__color_button: rgba(228, 228, 231, 0.88);
+    --yarl__color_button_active: rgba(255, 255, 255, 1);
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -127,6 +127,17 @@
     z-index: 2;
   }
 
+  .yarl__container {
+    backdrop-filter: blur(2px);
+  }
+
+  .yarl__slide_image {
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+    padding: 8px;
+  }
+
   .mermaid-diagram svg,
   .mermaid-lightbox-content svg {
     width: 100%;
@@ -229,6 +240,11 @@
       --muted: #a1a1aa !important;
       --surface: #1f1f23 !important;
       --border: #3f3f46 !important;
+    }
+
+    .yarl__slide_image {
+      background: #18181b;
+      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
     }
 
     .mermaid-lightbox-stage {
@@ -350,9 +366,9 @@
   --accent-warm: #ea580c;
 
   /* Yet Another React Lightbox theme (light) */
-  --yarl__color_backdrop: rgba(253, 253, 247, 0.94);
-  --yarl__container_background_color: rgba(253, 253, 247, 0.94);
-  --yarl__color_button: rgba(39, 39, 42, 0.88);
+  --yarl__color_backdrop: rgba(253, 253, 247, 0.98);
+  --yarl__container_background_color: rgba(253, 253, 247, 0.98);
+  --yarl__color_button: rgba(39, 39, 42, 0.9);
   --yarl__color_button_active: rgba(17, 24, 39, 1);
   --yarl__button_filter: none;
 }

--- a/src/components/MermaidZoomable.tsx
+++ b/src/components/MermaidZoomable.tsx
@@ -16,9 +16,32 @@ function toSvgDataUrl(svg: string): string {
   return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(normalized)}`;
 }
 
+function parseSvgDimensions(svg: string): { width: number; height: number } {
+  const viewBoxMatch = svg.match(/viewBox\s*=\s*"([^"]+)"/i);
+  if (viewBoxMatch) {
+    const nums = viewBoxMatch[1]
+      .trim()
+      .split(/\s+/)
+      .map((part) => Number(part));
+    if (nums.length === 4 && nums[2] > 0 && nums[3] > 0) {
+      return { width: nums[2], height: nums[3] };
+    }
+  }
+
+  const widthMatch = svg.match(/width\s*=\s*"([0-9.]+)"/i);
+  const heightMatch = svg.match(/height\s*=\s*"([0-9.]+)"/i);
+  const width = widthMatch ? Number(widthMatch[1]) : 1200;
+  const height = heightMatch ? Number(heightMatch[1]) : 800;
+  return {
+    width: Number.isFinite(width) && width > 0 ? width : 1200,
+    height: Number.isFinite(height) && height > 0 ? height : 800,
+  };
+}
+
 export default function MermaidZoomable({ svg }: MermaidZoomableProps) {
   const [open, setOpen] = useState(false);
   const src = useMemo(() => toSvgDataUrl(svg), [svg]);
+  const dimensions = useMemo(() => parseSvgDimensions(svg), [svg]);
 
   return (
     <>
@@ -35,12 +58,23 @@ export default function MermaidZoomable({ svg }: MermaidZoomableProps) {
       <Lightbox
         open={open}
         close={() => setOpen(false)}
-        slides={[{ src, alt: "mermaid diagram" }]}
+        slides={[
+          {
+            src,
+            alt: "mermaid diagram",
+            width: dimensions.width,
+            height: dimensions.height,
+          },
+        ]}
         plugins={[Zoom]}
         index={0}
         carousel={{ finite: true, preload: 0 }}
         controller={{ closeOnBackdropClick: true }}
-        zoom={{ maxZoomPixelRatio: 4, wheelZoomDistanceFactor: 80, pinchZoomDistanceFactor: 80 }}
+        zoom={{
+          maxZoomPixelRatio: 4,
+          wheelZoomDistanceFactor: 80,
+          pinchZoomDistanceFactor: 80,
+        }}
         render={{
           buttonPrev: () => null,
           buttonNext: () => null,


### PR DESCRIPTION
## Summary
- migrate Mermaid preview lightbox to `yet-another-react-lightbox`
- use mature zoom interactions for mobile pinch/pan stability
- keep single-slide (non-gallery) behavior for docs
- align lightbox colors with site theme (light/dark)

## Validation
- pnpm lint
- pnpm typecheck
