### PR TITLE
fix: mermaid theme contrast (avoid transparent bg)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -143,7 +143,11 @@
     width: 100%;
     height: auto;
     display: block;
-    --bg: transparent !important;
+
+    /* beautiful-mermaid themes rely on --bg for color-mix derivations.
+       Forcing transparent here makes node fills/edges look washed out.
+       Use the page background for consistent contrast. */
+    --bg: var(--background) !important;
     --fg: #27272a !important;
     --line: #52525b !important;
     --accent: #2563eb !important;
@@ -233,7 +237,7 @@
 
     .mermaid-diagram svg,
     .mermaid-lightbox-content svg {
-      --bg: transparent !important;
+      --bg: var(--background) !important;
       --fg: #e4e4e7 !important;
       --line: #a1a1aa !important;
       --accent: #93c5fd !important;

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -132,7 +132,9 @@ export default async function MarkdownRenderer({
                 const svg = await renderMermaid(normalizedMermaidText, {
                   ...THEMES["zinc-light"],
                   font: "Inter",
-                  transparent: true,
+                  // Keep theme background so node fills/lines have stable contrast.
+                  // A transparent bg breaks some color-mix derivations.
+                  transparent: false,
                 });
                 return <MermaidZoomable svg={svg} />;
               } catch {


### PR DESCRIPTION
## Summary
Restore stable beautiful-mermaid theming by avoiding transparent background overrides.

## Changes
- `src/components/MarkdownRenderer.tsx`: renderMermaid `transparent: false`
- `src/app/globals.css`: stop forcing `--bg: transparent`; use `--bg: var(--background)` for consistent color-mix derivations

## Why
beautiful-mermaid themes derive node fill/lines from `--bg` via CSS `color-mix()`. Forcing transparent `--bg` causes washed-out/odd-looking diagrams.
