### PR TITLE
feat: SEO basics (robots.txt, sitemap.xml, canonical)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,9 @@ const outfit = Outfit({
 
 export const metadata: Metadata = {
   metadataBase: new URL(
-    process.env.NEXT_PUBLIC_SITE_URL || "https://www.parkgogogo.me"
+    process.env.NEXT_PUBLIC_SITE_URL ||
+      process.env.SITE_URL ||
+      "https://www.parkgogogo.me"
   ),
   title: "Parkgogogo",
   description: "Park's personal website",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,8 +26,14 @@ const outfit = Outfit({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL || "https://www.parkgogogo.me"
+  ),
   title: "Parkgogogo",
   description: "Park's personal website",
+  alternates: {
+    canonical: "/",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,9 @@
 import type { MetadataRoute } from "next";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://www.parkgogogo.me";
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  process.env.SITE_URL ||
+  "https://www.parkgogogo.me";
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://www.parkgogogo.me";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,10 @@
 import type { MetadataRoute } from "next";
 import { PostService } from "@/lib/posts";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://www.parkgogogo.me";
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  process.env.SITE_URL ||
+  "https://www.parkgogogo.me";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const posts = await PostService.getAllPosts();

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,32 @@
+import type { MetadataRoute } from "next";
+import { PostService } from "@/lib/posts";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://www.parkgogogo.me";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const posts = await PostService.getAllPosts();
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: SITE_URL,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/blog`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.8,
+    },
+  ];
+
+  const postRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: `${SITE_URL}/blog/${encodeURIComponent(post.slug)}`,
+    lastModified: post.date ? new Date(post.date) : new Date(),
+    changeFrequency: "monthly",
+    priority: 0.6,
+  }));
+
+  return [...staticRoutes, ...postRoutes];
+}


### PR DESCRIPTION
## Summary
Add basic SEO plumbing so Google can discover and index the site.

## Changes
- Add `src/app/robots.ts` → serves `/robots.txt`
- Add `src/app/sitemap.ts` → serves `/sitemap.xml` (includes home, /blog, and all posts)
- Set `metadataBase` + `alternates.canonical` in `src/app/layout.tsx`

## Notes
Set `NEXT_PUBLIC_SITE_URL=https://www.parkgogogo.me` in Vercel env for correct absolute URLs (defaults to that value if missing).
