### PR TITLE
fix(blog): wrap mobile post titles and normalize underscores

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -47,7 +47,7 @@ export default async function BlogPostPage({
         <div className="max-w-4xl mx-auto px-6 md:px-8 pt-6 pb-14 md:pb-20">
           <article className="bg-transparent">
             <header className="mb-6 md:mb-8">
-              <h1 className="text-2xl md:text-3xl font-medium font-display text-foreground mb-2 leading-tight tracking-tight mt-0">
+              <h1 className="text-2xl md:text-3xl font-medium font-display text-foreground mb-2 leading-tight tracking-tight mt-0 break-words">
                 {post.title}.md
               </h1>
               <p className="text-sm text-gray-500 dark:text-gray-400">
@@ -75,7 +75,7 @@ export default async function BlogPostPage({
           <div className="px-0 py-0">
             {/* Post Header */}
             <header className="mb-8 md:mb-12">
-              <h1 className="text-3xl font-medium font-display text-foreground mb-4 leading-tight tracking-tight mt-0">
+              <h1 className="text-3xl font-medium font-display text-foreground mb-4 leading-tight tracking-tight mt-0 break-words">
                 {post.title}
               </h1>
 

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -99,10 +99,15 @@ async function processMarkdownFile(
 
       const slug = file.name.replace(".md", "");
       const category = categoryPath.split("/").pop() || "uncategorized";
+      const normalizedSlugTitle = slug.replace(/_/g, " ");
+      const normalizedFrontmatterTitle =
+        typeof frontmatter.title === "string"
+          ? frontmatter.title.replace(/_/g, " ")
+          : undefined;
 
       return {
         slug,
-        title: frontmatter.title || slug,
+        title: normalizedFrontmatterTitle || normalizedSlugTitle,
         date: await getFileCreationDate(file.path),
         content: markdown,
         excerpt: frontmatter.excerpt || markdown.slice(0, 200) + "...",


### PR DESCRIPTION
### Motivation
- Prevent long unbroken blog titles (often containing underscores) from breaking layout on small screens and make displayed titles more natural by replacing underscores with spaces.
### Description
- Add `break-words` to the blog post `<h1>` in both raw-markdown and normal display modes to allow wrapping on mobile (`src/app/blog/[slug]/page.tsx`).
- Normalize titles when parsing markdown by replacing underscores in `slug` and `frontmatter.title` with spaces so UI shows spaces by default (`src/lib/posts.ts`).
### Testing
- Ran `pnpm run lint` and it completed with no ESLint errors.
- Ran `pnpm run typecheck` and `tsc` completed with no type errors.
- Started the dev server and captured a mobile screenshot via Playwright to visually validate wrapping; server compiled and the screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a98f329348333af4c1dd041523ca3)