### PR TITLE
feat(blog): add fade-in-up animation to post content

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -44,7 +44,7 @@ export default async function BlogPostPage({
         currentSlug={slug}
         content={post.content}
       >
-        <div className="max-w-4xl mx-auto px-6 md:px-8 pt-6 pb-14 md:pb-20">
+        <div className="max-w-4xl mx-auto px-6 md:px-8 pt-6 pb-14 md:pb-20 animate-fade-in-up">
           <article className="bg-transparent">
             <header className="mb-6 md:mb-8">
               <h1 className="text-2xl md:text-3xl font-medium font-display text-foreground mb-2 leading-tight tracking-tight mt-0 break-words">
@@ -70,7 +70,7 @@ export default async function BlogPostPage({
       currentSlug={slug}
       content={post.content}
     >
-      <div className="max-w-4xl mx-auto px-6 md:px-8 pt-6 pb-14 md:pb-20">
+      <div className="max-w-4xl mx-auto px-6 md:px-8 pt-6 pb-14 md:pb-20 animate-fade-in-up">
         <article className="bg-transparent">
           <div className="px-0 py-0">
             {/* Post Header */}


### PR DESCRIPTION
### Motivation: Make blog post pages use the same upward fade-in animation as the blog list so article text animates into view; ### Description: Added `animate-fade-in-up` to the outer container divs in `src/app/blog/[slug]/page.tsx` (applies to both normal post view and raw `.md` mode) so the article content enters with the same animation as the list; ### Testing: Ran `pnpm run lint` (no ESLint errors) and `pnpm run typecheck` (`tsc --noEmit`) successfully, started the dev server and captured a screenshot artifact of the blog post page (`artifacts/blog-post-fade-in.png`), noting dev warnings about remote font and GitHub fetch failures due to network restrictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699becf733ec83338ae6fa6ef3d23ee5)