### PR TITLE
feat(blog): slow down and delay fade-in animation

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -44,7 +44,7 @@ export default async function BlogPostPage({
         currentSlug={slug}
         content={post.content}
       >
-        <div className="max-w-4xl mx-auto px-6 md:px-8 pt-6 pb-14 md:pb-20 animate-fade-in-up">
+        <div className="max-w-4xl mx-auto px-6 md:px-8 pt-6 pb-14 md:pb-20 animate-fade-in-up-slow">
           <article className="bg-transparent">
             <header className="mb-6 md:mb-8">
               <h1 className="text-2xl md:text-3xl font-medium font-display text-foreground mb-2 leading-tight tracking-tight mt-0 break-words">
@@ -70,7 +70,7 @@ export default async function BlogPostPage({
       currentSlug={slug}
       content={post.content}
     >
-      <div className="max-w-4xl mx-auto px-6 md:px-8 pt-6 pb-14 md:pb-20 animate-fade-in-up">
+      <div className="max-w-4xl mx-auto px-6 md:px-8 pt-6 pb-14 md:pb-20 animate-fade-in-up-slow">
         <article className="bg-transparent">
           <div className="px-0 py-0">
             {/* Post Header */}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -25,7 +25,7 @@ function CategorySection({ category }: { category: Category }) {
   }
 
   return (
-    <div className="space-y-12 animate-fade-in-up">
+    <div className="space-y-12 animate-fade-in-up-slow">
       {allPosts.map((post) => (
         <article key={post.slug} className="group">
           <Link href={`/blog/${post.slug}`}>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1188,6 +1188,10 @@ body {
   animation: fade-in-up 0.8s ease-out forwards;
 }
 
+.animate-fade-in-up-slow {
+  animation: fade-in-up 1.1s ease-out 0.16s forwards;
+}
+
 .animate-shooting-star {
   animation: shooting-star 6s linear infinite;
 }


### PR DESCRIPTION
### Motivation: Make blog list and post entrances feel smoother and slightly delayed for a better UX; ### Description: Added a new CSS utility `.animate-fade-in-up-slow` to `src/app/globals.css` with `animation: fade-in-up 1.1s ease-out 0.16s forwards` and replaced usages of `animate-fade-in-up` with `animate-fade-in-up-slow` in `src/app/blog/page.tsx` and `src/app/blog/[slug]/page.tsx`; ### Testing: Ran `pnpm run lint` and `pnpm run typecheck`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bf53b35ec8333be957909c28a95f7)