### PR TITLE
fix: tighten article layout chrome

### DIFF
--- a/src/app/blog/(post)/[slug]/page.test.tsx
+++ b/src/app/blog/(post)/[slug]/page.test.tsx
@@ -42,6 +42,7 @@ describe("BlogPostPage", () => {
     const html = renderToStaticMarkup(element);
 
     expect(html).toContain("Hello World");
+    expect(html).toContain("max-w-[650px]");
     expect(html).toContain("text-[color:var(--foreground-strong)]");
     expect(html).toContain("text-[color:var(--text-muted)]");
     expect(html).toContain(

--- a/src/app/blog/(post)/[slug]/page.tsx
+++ b/src/app/blog/(post)/[slug]/page.tsx
@@ -34,7 +34,7 @@ export default async function BlogPostPage({
     }
 
     return (
-      <div className="max-w-4xl mx-auto px-6 md:px-8 pt-6 pb-14 md:pb-20 animate-fade-in-up-slow">
+      <div className="mx-auto max-w-[650px] px-6 pt-6 pb-14 md:px-8 md:pb-20 animate-fade-in-up-slow">
         <article className="bg-transparent">
           <header className="mb-6 md:mb-8">
             <h1 className="text-2xl md:text-3xl font-medium font-display text-[color:var(--foreground-strong)] mb-2 leading-tight tracking-tight mt-0 break-words">
@@ -54,7 +54,7 @@ export default async function BlogPostPage({
   }
 
   return (
-    <div className="max-w-4xl mx-auto px-6 md:px-8 pt-6 pb-14 md:pb-20 animate-fade-in-up-slow">
+    <div className="mx-auto max-w-[650px] px-6 pt-6 pb-14 md:px-8 md:pb-20 animate-fade-in-up-slow">
       <article className="bg-transparent">
         <div className="px-0 py-0">
           {/* Post Header */}

--- a/src/app/blog/layout.test.tsx
+++ b/src/app/blog/layout.test.tsx
@@ -1,0 +1,18 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import BlogLayout from "./layout";
+
+describe("BlogLayout", () => {
+  it("keeps the desktop logo fixed near the top-left while content scrolls", async () => {
+    const element = await BlogLayout({
+      children: <main>Blog content</main>,
+    });
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain("Blog content");
+    expect(html).toContain("md:fixed");
+    expect(html).toContain("md:left-6");
+    expect(html).toContain("md:top-3");
+  });
+});

--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -9,10 +9,12 @@ export default async function BlogLayout({
 }) {
   return (
     <div className="min-h-screen bg-background">
-      <div className="pt-3 pb-4 px-6 flex items-center gap-4">
-        <Link href="/">
-          <Logo />
-        </Link>
+      <div className="px-6 pt-3 pb-4 md:h-16">
+        <div className="flex items-center gap-4 md:fixed md:left-6 md:top-3 md:z-40">
+          <Link href="/">
+            <Logo />
+          </Link>
+        </div>
       </div>
       {children}
     </div>


### PR DESCRIPTION
Tighten the blog post detail width to 650px and keep the desktop blog logo fixed near the top-left while scrolling on article pages, with regression tests for both behaviors.