### PR TITLE
fix: add generateStaticParams for instant blog post page loads

### DIFF
--- a/src/app/blog/(post)/[slug]/page.tsx
+++ b/src/app/blog/(post)/[slug]/page.tsx
@@ -5,6 +5,14 @@ import { PostService } from "@/lib/posts";
 
 export const revalidate = 300;
 
+export async function generateStaticParams() {
+  const slugs = await PostService.getSlugs();
+
+  return slugs.map((slug) => ({
+    slug,
+  }));
+}
+
 export default async function BlogPostPage({
   params,
 }: {


### PR DESCRIPTION
Add generateStaticParams to the blog post page to enable static generation of all blog posts at build time. This improves performance by making post pages load instantly instead of being dynamically rendered on first request. It uses PostService.getSlugs() to retrieve all available slugs.