### PR TITLE
fix: add generateStaticParams for instant blog post page loads

### DIFF
--- a/src/app/blog/(post)/[slug]/page.tsx
+++ b/src/app/blog/(post)/[slug]/page.tsx
@@ -5,6 +5,14 @@ import { PostService } from "@/lib/posts";
 
 export const revalidate = 300;
 
+export async function generateStaticParams() {
+  const slugs = await PostService.getSlugs();
+
+  return slugs.map((slug) => ({
+    slug,
+  }));
+}
+
 export default async function BlogPostPage({
   params,
 }: {


### PR DESCRIPTION
Adds generateStaticParams to src/app/blog/(post)/[slug]/page.tsx so blog post routes use cached post slugs for build-time prerendering and avoid the first-click wait.