### PR TITLE
Fix: Header logo fixed positioning on blog posts

### DIFF
--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -9,11 +9,11 @@ export default async function BlogLayout({
 }) {
   return (
     <div className="min-h-screen bg-background">
-      <div className="pt-3 pb-4 px-6 flex items-center gap-4">
+      <header className="sticky top-0 left-0 right-0 z-20 px-4 sm:px-6 py-3 flex items-center gap-4 bg-background/95 supports-[backdrop-filter]:bg-background/80 supports-[backdrop-filter]:backdrop-blur-sm border-b border-[color:var(--border-subtle)]">
         <Link href="/">
           <Logo />
         </Link>
-      </div>
+      </header>
       {children}
     </div>
   );


### PR DESCRIPTION
Makes the header logo stay visible when scrolling on blog post pages.