### PR TITLE
[codex] Improve blog SEO foundation

### DIFF
--- a/SEO.md
+++ b/SEO.md
@@ -1,0 +1,50 @@
+# SEO Long-Running Plan
+
+Owner: Codex automation
+Started: 2026-06-10
+Primary domain: https://www.parkgogogo.me
+
+## Objective
+
+Improve discoverability for Park's blog posts in search engines, then stop the recurring automation once the site has stable indexing and article pages expose healthy technical SEO signals.
+
+## Current Baseline
+
+- Public `robots.txt` allows crawling and points to `https://www.parkgogogo.me/sitemap.xml`.
+- Public `sitemap.xml` lists the home page, `/blog`, and 4 article URLs.
+- Public `/blog` currently renders a generic title and description: `Parkgogogo` / `Park's personal website`.
+- Public `/blog` currently uses canonical `https://www.parkgogogo.me`, which is wrong for the blog index.
+- Article pages do not yet have post-specific metadata or JSON-LD on main before this branch.
+- Google/Bing search visibility could not be reliably validated from local repository state; recurring checks should use public pages plus any available Search Console or search result evidence.
+
+## First-Round Implementation
+
+- Centralize site URL, title, author, and text cleanup helpers in `src/lib/seo.ts`.
+- Add richer root metadata, Open Graph, Twitter card, RSS alternate, crawler directives, and `zh-CN` document language.
+- Add `/blog` metadata, canonical URL, and Blog JSON-LD.
+- Add article-level `generateMetadata`, canonical URLs, Open Graph article metadata, Twitter metadata, and BlogPosting JSON-LD.
+- Mark raw markdown source views as `noindex` while canonicalizing them to the rendered article.
+- Make sitemap URLs and RSS feed URLs use the shared canonical site URL.
+
+## Recurring Review Checklist
+
+1. Fetch `https://www.parkgogogo.me/robots.txt` and confirm it allows content crawling, disallows only non-content routes, and references the sitemap.
+2. Fetch `https://www.parkgogogo.me/sitemap.xml` and confirm all published blog posts are present with canonical encoded URLs and plausible `lastmod` values.
+3. Fetch `https://www.parkgogogo.me/blog` and at least the newest 3 article URLs from the sitemap. Check title, meta description, canonical, Open Graph, Twitter, and JSON-LD.
+4. Check for duplicate indexable raw markdown URLs ending in `.md`; they should be `noindex` and canonicalize to the rendered article.
+5. Review whether new posts have specific frontmatter `title`, useful `excerpt`, and tags when relevant.
+6. If Search Console or an equivalent source is available, compare indexed pages, impressions, clicks, average position, and crawl/indexing issues against the previous run.
+7. If issues are found, create a branch from `origin/main`, implement a focused fix, run `pnpm run lint` and `pnpm run typecheck`, open a PR, and merge when checks pass.
+8. If the objective is met for 3 consecutive reviews, disable the SEO automation and append the stop reason here.
+
+## Success Criteria
+
+- `/blog` and article pages have distinct canonical URLs, titles, descriptions, and valid JSON-LD.
+- Sitemap and robots remain reachable from the public domain.
+- All current blog posts are present in the sitemap and have indexable rendered article pages.
+- Raw markdown source pages are not competing with rendered article pages.
+- Search visibility is considered acceptable after either Search Console shows stable indexed article pages and non-zero impressions/clicks, or repeated public search checks show the core article URLs indexed.
+
+## Review Log
+
+- 2026-06-10: Created baseline plan and first technical SEO implementation branch from `origin/main`.

--- a/src/app/blog/(list)/page.tsx
+++ b/src/app/blog/(list)/page.tsx
@@ -1,41 +1,45 @@
 import Link from "next/link";
 import Image from "next/image";
+import type { Metadata } from "next";
 import { format } from "date-fns";
 import { BlogPost, Category } from "@/types/blog";
 import { PostService } from "@/lib/posts";
+import {
+  absoluteUrl,
+  blogPostPath,
+  collectCategoryPosts,
+  postDescription,
+  siteConfig,
+} from "@/lib/seo";
 
 export const revalidate = false;
 
-function getDisplayExcerpt(post: BlogPost): string {
-  const source = post.excerpt || post.content;
+export const metadata: Metadata = {
+  title: "Blog",
+  description: siteConfig.description,
+  alternates: {
+    canonical: "/blog",
+  },
+  openGraph: {
+    type: "website",
+    url: "/blog",
+    title: "Blog",
+    description: siteConfig.description,
+    siteName: siteConfig.name,
+  },
+  twitter: {
+    card: "summary",
+    title: "Blog",
+    description: siteConfig.description,
+  },
+};
 
-  return source
-    .replace(/```[\s\S]*?```/g, " ")
-    .replace(/`([^`]+)`/g, "$1")
-    .replace(/!\[[^\]]*]\([^)]*\)/g, " ")
-    .replace(/\[([^\]]+)]\([^)]*\)/g, "$1")
-    .replace(/^#{1,6}\s+/gm, "")
-    .replace(/[#*_>~-]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+function getDisplayExcerpt(post: BlogPost): string {
+  return postDescription(post);
 }
 
 function CategorySection({ category }: { category: Category }) {
-  const getAllPosts = (cat: Category): BlogPost[] => {
-    let posts = [...cat.posts];
-    if (cat.subcategories) {
-      cat.subcategories.forEach((subcat) => {
-        posts = [...posts, ...getAllPosts(subcat)];
-      });
-    }
-    return posts;
-  };
-
-  const allPosts = getAllPosts(category).sort((a, b) => {
-    const ta = new Date(a.date).getTime();
-    const tb = new Date(b.date).getTime();
-    return tb - ta;
-  });
+  const allPosts = collectCategoryPosts(category);
 
   if (allPosts.length === 0) {
     return null;
@@ -75,9 +79,35 @@ function CategorySection({ category }: { category: Category }) {
 
 export default async function BlogPage() {
   const categories = await PostService.getCategory();
+  const allPosts = collectCategoryPosts(categories);
+  const blogJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Blog",
+    name: siteConfig.name,
+    description: siteConfig.description,
+    url: absoluteUrl("/blog"),
+    inLanguage: "zh-CN",
+    publisher: {
+      "@type": "Person",
+      name: siteConfig.author.name,
+      url: siteConfig.author.url,
+    },
+    blogPost: allPosts.slice(0, 20).map((post) => ({
+      "@type": "BlogPosting",
+      headline: post.title,
+      description: postDescription(post),
+      url: absoluteUrl(blogPostPath(post.slug)),
+      datePublished: post.date,
+      dateModified: post.date,
+    })),
+  };
 
   return (
     <div className="mx-auto w-full max-w-[72rem] px-4 py-4 sm:px-6 md:py-10 lg:px-8 lg:py-12">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(blogJsonLd) }}
+      />
       <header className="mx-auto mb-1 max-w-3xl">
         <h1 className="sr-only">Blog</h1>
         <div className="blog-subtitle-write mt-3" aria-label="随手记点东西">

--- a/src/app/blog/(post)/[slug]/page.tsx
+++ b/src/app/blog/(post)/[slug]/page.tsx
@@ -1,8 +1,15 @@
 import { notFound } from "next/navigation";
+import type { Metadata } from "next";
 import { format } from "date-fns";
 import Link from "next/link";
 import MarkdownRenderer from "@/components/MarkdownRenderer";
 import { PostService } from "@/lib/posts";
+import {
+  absoluteUrl,
+  blogPostPath,
+  postDescription,
+  siteConfig,
+} from "@/lib/seo";
 
 export const revalidate = false;
 
@@ -12,6 +19,62 @@ export async function generateStaticParams() {
   return slugs.map((slug) => ({
     slug,
   }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug: rawSlug } = await params;
+  const decodedSlug = decodeURIComponent(rawSlug);
+  const isRawMarkdownMode = decodedSlug.endsWith(".md");
+  const slug = isRawMarkdownMode ? decodedSlug.slice(0, -3) : decodedSlug;
+  const post = await PostService.getPostBySlug(slug);
+
+  if (!post) {
+    return {
+      title: "Post not found",
+      robots: {
+        index: false,
+        follow: false,
+      },
+    };
+  }
+
+  const canonicalPath = blogPostPath(post.slug);
+  const description = postDescription(post);
+  const title = isRawMarkdownMode ? `${post.title}.md` : post.title;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: canonicalPath,
+    },
+    robots: isRawMarkdownMode
+      ? {
+          index: false,
+          follow: true,
+        }
+      : undefined,
+    openGraph: {
+      type: "article",
+      url: canonicalPath,
+      title: post.title,
+      description,
+      siteName: siteConfig.name,
+      publishedTime: post.date,
+      modifiedTime: post.date,
+      authors: [siteConfig.author.name],
+      tags: post.tags,
+    },
+    twitter: {
+      card: "summary",
+      title: post.title,
+      description,
+    },
+  };
 }
 
 export default async function BlogPostPage({
@@ -62,8 +125,37 @@ export default async function BlogPostPage({
     );
   }
 
+  const articleJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.title,
+    description: postDescription(post),
+    url: absoluteUrl(blogPostPath(post.slug)),
+    mainEntityOfPage: absoluteUrl(blogPostPath(post.slug)),
+    datePublished: post.date,
+    dateModified: post.date,
+    inLanguage: "zh-CN",
+    author: {
+      "@type": "Person",
+      name: siteConfig.author.name,
+      url: siteConfig.author.url,
+    },
+    publisher: {
+      "@type": "Person",
+      name: siteConfig.author.name,
+      url: siteConfig.author.url,
+    },
+    articleSection: post.category,
+    keywords: post.tags?.length ? post.tags.join(", ") : undefined,
+    timeRequired: post.readingTime ? `PT${post.readingTime}M` : undefined,
+  };
+
   return (
     <div className="mx-auto w-full max-w-[72rem] px-4 py-10 sm:px-6 lg:px-8 lg:py-12">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
+      />
       <article className="max-w-3xl bg-transparent">
         <div className="px-0 py-0">
           <header className="mb-3 md:mb-12">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import {
   Geist,
   Geist_Mono,
@@ -6,6 +6,7 @@ import {
   Noto_Serif_SC,
   Outfit,
 } from "next/font/google";
+import { siteConfig } from "@/lib/seo";
 import "yet-another-react-lightbox/styles.css";
 import "./globals.css";
 
@@ -39,16 +40,51 @@ const notoSerifSc = Noto_Serif_SC({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL(
-    process.env.NEXT_PUBLIC_SITE_URL ||
-      process.env.SITE_URL ||
-      "https://www.parkgogogo.me"
-  ),
-  title: "Parkgogogo",
-  description: "Park's personal website",
+  metadataBase: new URL(siteConfig.url),
+  title: {
+    default: siteConfig.title,
+    template: `%s | ${siteConfig.name}`,
+  },
+  description: siteConfig.description,
+  applicationName: siteConfig.name,
+  authors: [{ name: siteConfig.author.name, url: siteConfig.author.url }],
+  creator: siteConfig.author.name,
+  publisher: siteConfig.author.name,
   alternates: {
     canonical: "/",
+    types: {
+      "application/rss+xml": "/rss/blog.xml",
+    },
   },
+  openGraph: {
+    type: "website",
+    locale: "zh_CN",
+    url: "/",
+    siteName: siteConfig.name,
+    title: siteConfig.title,
+    description: siteConfig.description,
+  },
+  twitter: {
+    card: "summary",
+    title: siteConfig.title,
+    description: siteConfig.description,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
+  },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({
@@ -57,10 +93,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </head>
+    <html lang="zh-CN">
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${inter.variable} ${outfit.variable} ${notoSerifSc.variable} antialiased scrollbar-hide`}
       >

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,9 +1,5 @@
 import type { MetadataRoute } from "next";
-
-const SITE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL ||
-  process.env.SITE_URL ||
-  "https://www.parkgogogo.me";
+import { absoluteUrl } from "@/lib/seo";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -11,8 +7,9 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "*",
         allow: "/",
+        disallow: ["/api/", "/e2e/"],
       },
     ],
-    sitemap: `${SITE_URL}/sitemap.xml`,
+    sitemap: absoluteUrl("/sitemap.xml"),
   };
 }

--- a/src/app/rss/blog.xml/route.ts
+++ b/src/app/rss/blog.xml/route.ts
@@ -1,24 +1,25 @@
 import { PostService } from "@/lib/posts";
+import {
+  absoluteUrl,
+  blogPostPath,
+  postDescription,
+  siteConfig,
+} from "@/lib/seo";
 import RSS from "rss";
 
 export const dynamic = "force-static";
 
 /**
- * GET /rss/blog
+ * GET /rss/blog.xml
  * Builds an RSS feed from markdown posts fetched via src/lib/posts.ts
  */
 export async function GET() {
-  const siteUrl =
-    process.env.NEXT_PUBLIC_SITE_URL ||
-    process.env.SITE_URL ||
-    "http://localhost:3000";
-
   const feed = new RSS({
     title: "Park's Blog",
-    description: "Latest posts",
-    feed_url: `${siteUrl}/rss/blog`,
-    site_url: siteUrl,
-    image_url: `${siteUrl}/park_logo.svg`,
+    description: siteConfig.description,
+    feed_url: absoluteUrl("/rss/blog.xml"),
+    site_url: siteConfig.url,
+    image_url: absoluteUrl("/park_logo.svg"),
   });
 
   try {
@@ -27,9 +28,9 @@ export async function GET() {
     for (const post of posts) {
       feed.item({
         title: post.title,
-        description: post.excerpt ?? "",
-        url: `${siteUrl}/blog/${encodeURIComponent(post.slug)}`,
-        guid: `${siteUrl}/blog/${post.slug}`,
+        description: postDescription(post),
+        url: absoluteUrl(blogPostPath(post.slug)),
+        guid: absoluteUrl(blogPostPath(post.slug)),
         date: post.date,
         // include full content as CDATA so HTML/markdown won't break the feed
         custom_elements: [{ "content:encoded": { _cdata: post.content } }],

--- a/src/app/rss/words.xml/route.ts
+++ b/src/app/rss/words.xml/route.ts
@@ -1,24 +1,20 @@
 import RSS from "rss";
 import { WordsService } from "@/lib/words";
+import { absoluteUrl, siteConfig } from "@/lib/seo";
 
 export const dynamic = "force-dynamic";
 
 /**
- * GET /rss/blog
+ * GET /rss/words.xml
  * Builds an RSS feed from markdown posts fetched via src/lib/posts.ts
  */
 export async function GET() {
-  const siteUrl =
-    process.env.NEXT_PUBLIC_SITE_URL ||
-    process.env.SITE_URL ||
-    "http://localhost:3000";
-
   const feed = new RSS({
     title: "Park's Daily Words",
     description: "lulu words",
-    feed_url: siteUrl,
-    site_url: siteUrl,
-    image_url: `${siteUrl}/park_logo.svg`,
+    feed_url: absoluteUrl("/rss/words.xml"),
+    site_url: siteConfig.url,
+    image_url: absoluteUrl("/park_logo.svg"),
   });
 
   try {
@@ -31,7 +27,7 @@ export async function GET() {
         feed.item({
           title: `Daily Words ${key}`,
           description: "",
-          url: `${siteUrl}/words/${key}`,
+          url: absoluteUrl(`/words/${key}`),
           date: key,
           custom_elements: [
             {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,31 +1,27 @@
 import type { MetadataRoute } from "next";
 import { PostService } from "@/lib/posts";
-
-const SITE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL ||
-  process.env.SITE_URL ||
-  "https://www.parkgogogo.me";
+import { absoluteUrl, blogPostPath, siteConfig } from "@/lib/seo";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const posts = await PostService.getAllPosts();
 
   const staticRoutes: MetadataRoute.Sitemap = [
     {
-      url: SITE_URL,
-      lastModified: new Date(),
+      url: siteConfig.url,
+      lastModified: posts[0]?.date ? new Date(posts[0].date) : new Date(),
       changeFrequency: "weekly",
       priority: 1,
     },
     {
-      url: `${SITE_URL}/blog`,
-      lastModified: new Date(),
+      url: absoluteUrl("/blog"),
+      lastModified: posts[0]?.date ? new Date(posts[0].date) : new Date(),
       changeFrequency: "daily",
       priority: 0.8,
     },
   ];
 
   const postRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
-    url: `${SITE_URL}/blog/${encodeURIComponent(post.slug)}`,
+    url: absoluteUrl(blogPostPath(post.slug)),
     lastModified: post.date ? new Date(post.date) : new Date(),
     changeFrequency: "monthly",
     priority: 0.6,

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,71 @@
+import type { BlogPost, Category } from "@/types/blog";
+
+const DEFAULT_SITE_URL = "https://www.parkgogogo.me";
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+const siteUrl = trimTrailingSlash(
+  process.env.NEXT_PUBLIC_SITE_URL || process.env.SITE_URL || DEFAULT_SITE_URL,
+);
+
+export const siteConfig = {
+  name: "Parkgogogo",
+  title: "Parkgogogo",
+  description: "Park 的个人博客，记录前端工程、AI 编程、产品思考和日常写作。",
+  author: {
+    name: "Park",
+    url: siteUrl,
+  },
+  url: siteUrl,
+};
+
+export function absoluteUrl(path = "/"): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${siteConfig.url}${normalizedPath}`;
+}
+
+export function blogPostPath(slug: string): string {
+  return `/blog/${encodeURIComponent(slug)}`;
+}
+
+export function stripMarkdownToText(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/!\[[^\]]*]\([^)]*\)/g, " ")
+    .replace(/\[([^\]]+)]\([^)]*\)/g, "$1")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^>\s?/gm, "")
+    .replace(/[#*_~`[\]()<>-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function truncateText(text: string, maxLength = 160): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  return `${text.slice(0, maxLength - 1).trim()}…`;
+}
+
+export function postDescription(post: BlogPost): string {
+  const source = post.excerpt || post.content;
+  const description = truncateText(stripMarkdownToText(source), 160);
+
+  return description || siteConfig.description;
+}
+
+export function collectCategoryPosts(category: Category): BlogPost[] {
+  const posts = [...category.posts];
+
+  for (const subcategory of category.subcategories || []) {
+    posts.push(...collectCategoryPosts(subcategory));
+  }
+
+  return posts.sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+  );
+}


### PR DESCRIPTION
Summary: Add shared SEO helpers, richer site/blog/article metadata, JSON-LD, canonical sitemap/RSS URLs, crawler rules, and SEO.md for long-running automation handoff. Validation: pnpm run lint; pnpm run typecheck; pnpm exec vitest run src/app/blog/(post)/[slug]/page.test.tsx.