### PR TITLE
[codex] Canonicalize blog root redirect

### DIFF
--- a/SEO.md
+++ b/SEO.md
@@ -78,4 +78,5 @@ Cadence:
 
 ## Review Log
 
+- 2026-06-10: Fixed the root canonical signal by making `/` a permanent redirect to `/blog` and removing the redirecting root URL from `sitemap.xml`.
 - 2026-06-10: Created baseline plan and first technical SEO implementation branch from `origin/main`.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from "next/navigation";
+import { permanentRedirect } from "next/navigation";
 
 export default function HomePage() {
-  redirect("/blog");
+  permanentRedirect("/blog");
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,22 +1,16 @@
 import type { MetadataRoute } from "next";
 import { PostService } from "@/lib/posts";
-import { absoluteUrl, blogPostPath, siteConfig } from "@/lib/seo";
+import { absoluteUrl, blogPostPath } from "@/lib/seo";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const posts = await PostService.getAllPosts();
 
   const staticRoutes: MetadataRoute.Sitemap = [
     {
-      url: siteConfig.url,
-      lastModified: posts[0]?.date ? new Date(posts[0].date) : new Date(),
-      changeFrequency: "weekly",
-      priority: 1,
-    },
-    {
       url: absoluteUrl("/blog"),
       lastModified: posts[0]?.date ? new Date(posts[0].date) : new Date(),
       changeFrequency: "daily",
-      priority: 0.8,
+      priority: 1,
     },
   ];
 


### PR DESCRIPTION
Summary: Make the root path permanently redirect to /blog, remove the redirecting root URL from sitemap.xml, and record the SEO fix in SEO.md. Validation: pnpm run lint; pnpm run typecheck.