### PR TITLE
fix: adjust markdown article spacing

### DIFF
--- a/src/app/blog/(post)/[slug]/page.test.tsx
+++ b/src/app/blog/(post)/[slug]/page.test.tsx
@@ -51,6 +51,18 @@ describe("BlogPostPage", () => {
     expect(html).toContain("text-[color:var(--text-muted)]");
   });
 
+  it("keeps article tags close to the metadata and body", async () => {
+    const element = await BlogPostPage({
+      params: Promise.resolve({ slug: "hello-world" }),
+    });
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain("mb-4");
+    expect(html).toContain("mt-3 flex flex-wrap gap-2");
+    expect(html).not.toContain("md:mb-12");
+    expect(html).not.toContain("md:mt-8");
+  });
+
   it("renders raw markdown mode with the redesigned source panel", async () => {
     const element = await BlogPostPage({
       params: Promise.resolve({ slug: "hello-world.md" }),

--- a/src/app/blog/(post)/[slug]/page.tsx
+++ b/src/app/blog/(post)/[slug]/page.tsx
@@ -158,7 +158,7 @@ export default async function BlogPostPage({
       />
       <article className="max-w-3xl bg-transparent">
         <div className="px-0 py-0">
-          <header className="mb-3 md:mb-12">
+          <header className="mb-4">
             <h1 className="mb-3 break-words text-[30px] font-semibold leading-[42px] text-[color:var(--foreground-strong)]">
               {post.title}
             </h1>
@@ -174,7 +174,7 @@ export default async function BlogPostPage({
             </div>
 
             {post.tags && post.tags.length > 0 && (
-              <div className="mt-5 flex flex-wrap gap-2">
+              <div className="mt-3 flex flex-wrap gap-2">
                 {post.tags.map((tag: string, index: number) => (
                   <span
                     key={index}
@@ -187,7 +187,7 @@ export default async function BlogPostPage({
             )}
           </header>
 
-          <div className="mt-0 md:mt-8">
+          <div className="mt-0">
             <MarkdownRenderer content={post.content} />
           </div>
         </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -75,11 +75,23 @@
   }
 
   .markdown-body hr {
-    display: none;
+    height: 1px;
+    margin-block: 2.25em 1.35em;
+    margin-inline: 0;
+    padding: 0;
+    border: 0;
+    background: var(
+      --border-subtle,
+      color-mix(in srgb, var(--foreground) 14%, transparent)
+    );
   }
 
   .markdown-body p {
     margin-block: 0;
+  }
+
+  .markdown-body > :first-child {
+    margin-top: 0 !important;
   }
 
   .markdown-body p + p,
@@ -103,6 +115,26 @@
 
   .markdown-body li + li {
     margin-top: 0.42em;
+  }
+
+  .markdown-body .markdown-tagline {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .markdown-body .markdown-tagline .hashtag {
+    margin: 0;
+  }
+
+  .markdown-body .markdown-tagline + h1,
+  .markdown-body .markdown-tagline + h2,
+  .markdown-body .markdown-tagline + h3,
+  .markdown-body .markdown-tagline + h4,
+  .markdown-body .markdown-tagline + h5,
+  .markdown-body .markdown-tagline + h6 {
+    margin-top: 1.5rem !important;
   }
 
   .markdown-body blockquote {

--- a/src/app/globals.test.ts
+++ b/src/app/globals.test.ts
@@ -33,3 +33,29 @@ describe("global theme tokens", () => {
     expect(css).toContain('[data-theme="light"] .blog-doc-shell');
   });
 });
+
+describe("markdown article spacing", () => {
+  it("renders horizontal rules as visible section separators", () => {
+    const css = readFileSync(globalsCssPath, "utf8");
+    const hrRule = css.match(/\.markdown-body hr\s*\{([^}]*)\}/)?.[1] ?? "";
+
+    expect(hrRule).not.toContain("display: none");
+    expect(hrRule).toContain("height: 1px;");
+    expect(hrRule).toContain("margin-block: 2.25em 1.35em;");
+  });
+
+  it("removes leading margin from the first markdown block", () => {
+    const css = readFileSync(globalsCssPath, "utf8");
+    const firstChildRule =
+      css.match(/\.markdown-body > :first-child\s*\{([^}]*)\}/)?.[1] ?? "";
+
+    expect(firstChildRule).toContain("margin-top: 0 !important;");
+  });
+
+  it("keeps standalone markdown taglines close to following headings", () => {
+    const css = readFileSync(globalsCssPath, "utf8");
+
+    expect(css).toContain(".markdown-body .markdown-tagline + h2");
+    expect(css).toContain("margin-top: 1.5rem !important;");
+  });
+});

--- a/src/components/MarkdownRenderer.test.tsx
+++ b/src/components/MarkdownRenderer.test.tsx
@@ -36,3 +36,13 @@ describe("MarkdownRenderer image rendering", () => {
     expect(html).toContain("data-nimg=");
   });
 });
+
+describe("MarkdownRenderer hashtag rendering", () => {
+  it("marks standalone hashtag paragraphs as a compact tagline", async () => {
+    const html = await renderMarkdown("#frontend #pitfall #ios\n\n## Title");
+
+    expect(html).toContain('class="markdown-tagline"');
+    expect(html).toContain('class="hashtag"');
+    expect(html).toContain('data-hashtag="frontend"');
+  });
+});

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -58,6 +58,14 @@ function processChildren(children: ReactNode): ReactNode {
     : processHashtagsInText(children);
 }
 
+function isHashtagOnlyParagraph(children: ReactNode): boolean {
+  const text = extractText(children).trim();
+
+  return /^#[a-zA-Z0-9_\u4e00-\u9fff]+(?:\s+#[a-zA-Z0-9_\u4e00-\u9fff]+)*$/.test(
+    text
+  );
+}
+
 function extractText(value: unknown): string {
   if (typeof value === "string") return value;
   if (typeof value === "number") return String(value);
@@ -131,7 +139,15 @@ export default async function MarkdownRenderer({
               {processChildren(children)}
             </h3>
           ),
-          p: ({ children }) => <p>{processChildren(children)}</p>,
+          p: ({ children }) => (
+            <p
+              className={
+                isHashtagOnlyParagraph(children) ? "markdown-tagline" : undefined
+              }
+            >
+              {processChildren(children)}
+            </p>
+          ),
           li: ({ children }) => <li>{processChildren(children)}</li>,
           code: async ({ className, children, node, ...props }) => {
             const language = className?.replace("language-", "");


### PR DESCRIPTION
Fix Markdown article spacing by restoring horizontal rule separation, compacting standalone hashtag taglines, and setting article tagline spacing to 16px above and 24px below; validated with pnpm run lint, pnpm run typecheck, targeted Vitest tests, and browser measurement.