### PR TITLE
[codex] improve blog metadata seo signals

### DIFF
--- a/SEO.md
+++ b/SEO.md
@@ -80,3 +80,6 @@ Cadence:
 
 - 2026-06-10: Fixed the root canonical signal by making `/` a permanent redirect to `/blog` and removing the redirecting root URL from `sitemap.xml`.
 - 2026-06-10: Created baseline plan and first technical SEO implementation branch from `origin/main`.
+- 2026-06-12: Daily public review via browser found `https://www.parkgogogo.me/blog` serving the expected canonical, title, description, Open Graph, Twitter, and Blog JSON-LD signals. Environment TLS issues prevented direct `curl`/git fetches to the public domain, so `robots.txt`, `sitemap.xml`, and RSS were only partially validated this run and need a normal network retry next run.
+- 2026-06-12: Bare-domain `https://parkgogogo.me/blog` resolved to a `Vercel Security Checkpoint` page instead of the blog. Treat this as a site-level SEO risk outside the app codepath until the domain/edge configuration is fixed.
+- 2026-06-12: Restored RSS feed alternates on `/blog` and article pages after child-route metadata overwrote the root alternate links. Also made the `/blog` title and description more specific to improve snippet clarity and CTR.

--- a/src/app/blog/(list)/page.tsx
+++ b/src/app/blog/(list)/page.tsx
@@ -6,31 +6,37 @@ import { BlogPost, Category } from "@/types/blog";
 import { PostService } from "@/lib/posts";
 import {
   absoluteUrl,
+  blogIndexDescription,
+  blogIndexKeywords,
+  blogIndexTitle,
   blogPostPath,
   collectCategoryPosts,
   postDescription,
+  rssAlternateTypes,
   siteConfig,
 } from "@/lib/seo";
 
 export const revalidate = false;
 
 export const metadata: Metadata = {
-  title: "Blog",
-  description: siteConfig.description,
+  title: blogIndexTitle,
+  description: blogIndexDescription,
+  keywords: blogIndexKeywords,
   alternates: {
     canonical: "/blog",
+    types: rssAlternateTypes(),
   },
   openGraph: {
     type: "website",
     url: "/blog",
-    title: "Blog",
-    description: siteConfig.description,
+    title: blogIndexTitle,
+    description: blogIndexDescription,
     siteName: siteConfig.name,
   },
   twitter: {
     card: "summary",
-    title: "Blog",
-    description: siteConfig.description,
+    title: blogIndexTitle,
+    description: blogIndexDescription,
   },
 };
 
@@ -83,8 +89,8 @@ export default async function BlogPage() {
   const blogJsonLd = {
     "@context": "https://schema.org",
     "@type": "Blog",
-    name: siteConfig.name,
-    description: siteConfig.description,
+    name: blogIndexTitle,
+    description: blogIndexDescription,
     url: absoluteUrl("/blog"),
     inLanguage: "zh-CN",
     publisher: {

--- a/src/app/blog/(post)/[slug]/page.test.tsx
+++ b/src/app/blog/(post)/[slug]/page.test.tsx
@@ -34,7 +34,7 @@ vi.mock("@/lib/posts", () => ({
   },
 }));
 
-import BlogPostPage from "./page";
+import BlogPostPage, { generateMetadata } from "./page";
 
 describe("BlogPostPage", () => {
   it("renders article metadata and markdown content", async () => {
@@ -76,5 +76,35 @@ describe("BlogPostPage", () => {
     expect(html).toContain(
       "border-[color:var(--border-default)] bg-[color:var(--surface-muted)]"
     );
+  });
+
+  it("includes canonical, rss, keywords, and category metadata for articles", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "hello-world" }),
+    });
+
+    expect(metadata.alternates?.canonical).toBe("/blog/hello-world");
+    expect(metadata.alternates?.types?.["application/rss+xml"]).toBe(
+      "https://www.parkgogogo.me/rss/blog.xml"
+    );
+    expect(metadata.category).toBe("notes");
+    expect(metadata.keywords).toEqual([
+      "design",
+      "notes",
+      "Park",
+      "博客",
+    ]);
+  });
+
+  it("marks raw markdown mode as noindex while keeping the rendered canonical", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "hello-world.md" }),
+    });
+
+    expect(metadata.alternates?.canonical).toBe("/blog/hello-world");
+    expect(metadata.robots).toEqual({
+      index: false,
+      follow: true,
+    });
   });
 });

--- a/src/app/blog/(post)/[slug]/page.tsx
+++ b/src/app/blog/(post)/[slug]/page.tsx
@@ -8,6 +8,7 @@ import {
   absoluteUrl,
   blogPostPath,
   postDescription,
+  rssAlternateTypes,
   siteConfig,
 } from "@/lib/seo";
 
@@ -49,8 +50,14 @@ export async function generateMetadata({
   return {
     title,
     description,
+    keywords: post.tags?.length
+      ? [...post.tags, post.category, siteConfig.author.name, "博客"]
+      : [post.category, siteConfig.author.name, "博客"],
+    category: post.category,
+    authors: [{ name: siteConfig.author.name, url: siteConfig.author.url }],
     alternates: {
       canonical: canonicalPath,
+      types: rssAlternateTypes(),
     },
     robots: isRawMarkdownMode
       ? {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import {
   Noto_Serif_SC,
   Outfit,
 } from "next/font/google";
-import { siteConfig } from "@/lib/seo";
+import { rssAlternateTypes, siteConfig } from "@/lib/seo";
 import "yet-another-react-lightbox/styles.css";
 import "./globals.css";
 
@@ -52,9 +52,7 @@ export const metadata: Metadata = {
   publisher: siteConfig.author.name,
   alternates: {
     canonical: "/",
-    types: {
-      "application/rss+xml": "/rss/blog.xml",
-    },
+    types: rssAlternateTypes(),
   },
   openGraph: {
     type: "website",

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -21,6 +21,18 @@ export const siteConfig = {
   url: siteUrl,
 };
 
+export const blogIndexTitle = "Park 的博客";
+export const blogIndexDescription =
+  "Park 的前端工程、AI 编程、产品思考与日常写作博客。";
+export const blogIndexKeywords = [
+  "Park",
+  "Parkgogogo",
+  "前端工程",
+  "AI 编程",
+  "产品思考",
+  "技术博客",
+];
+
 export function absoluteUrl(path = "/"): string {
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
   return `${siteConfig.url}${normalizedPath}`;
@@ -28,6 +40,12 @@ export function absoluteUrl(path = "/"): string {
 
 export function blogPostPath(slug: string): string {
   return `/blog/${encodeURIComponent(slug)}`;
+}
+
+export function rssAlternateTypes(): Record<string, string> {
+  return {
+    "application/rss+xml": absoluteUrl("/rss/blog.xml"),
+  };
 }
 
 export function stripMarkdownToText(markdown: string): string {


### PR DESCRIPTION
Restores RSS alternate links on blog and article pages, sharpens /blog title and description metadata for better snippets, adds article keyword/category signals, and documents the 2026-06-12 public SEO review including the bare-domain Vercel Security Checkpoint risk; validated with pnpm run lint, pnpm run typecheck, and pnpm test src/app/blog/(post)/[slug]/page.test.tsx.